### PR TITLE
Feature BRouter, Links in Sidebar for BRouter and Flopps, Config Value to turn both options off

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3272,48 +3272,51 @@ var mainGC = function () {
         } catch( e ) { gclh_error( "Driving direction for Waypoints: ", e ); }
     }
 
+    var css = "";
+    css += ".GClhdropbtn {";
+    css += "    cursor: pointer;";
+    css += "}";
+    css += ".GClhdropdown {";
+    css += "    position: relative;";
+    css += "    display: inline-block;";
+    css += "}";
+    css += ".GClhdropdown-content {";
+    css += "    display: none;";
+    css += "    position: absolute;";
+    css += "    background-color: #f9f9f9;";
+    css += "    min-width: 160px;";
+    css += "    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);";
+    css += "    z-index: 1;";
+    css += "}";
+    css += ".GClhdropdown-content-info {";
+    css += "    color: black;";
+    css += "    background-color: #ffffa5;";
+    css += "    padding: 5px 16px 5px 16px;";
+    css += "    text-decoration: none;";
+    css += "    display: none;";
+    css += "}";
+    css += ".GClhdropdown-content-info:hover {";
+    css += "    background-color: #ffffa5;";
+    css += "    cursor: default;";
+    css += "}";
+    css += ".GClhdropdown:hover .GClhdropdown-content {";
+    css += "    display: block;";
+    css += "}";
+    appendCssStyle( css );
+
 // Show button, which open Flopp's Map with all waypoints of a cache and open Flopp's Map.
     if (is_page("cache_listing") || document.location.href.match(/^https?:\/\/www\.geocaching\.com\/hide\/wptlist.aspx/)) {
         try {
             var css = "";
-            css += ".GClhdropbtn {";
-            css += "    cursor: pointer;";
-            css += "}";
-            css += ".GClhdropdown {";
-            css += "    position: relative;";
-            css += "    display: inline-block;";
-            css += "}";
-            css += ".GClhdropdown-content {";
-            css += "    display: none;";
-            css += "    position: absolute;";
-            css += "    background-color: #f9f9f9;";
-            css += "    min-width: 160px;";
-            css += "    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);";
-            css += "    z-index: 1;";
-            css += "}";
-            css += ".GClhdropdown-content-layer {";
+            css += ".FloppsMap-content-layer {";
             css += "    color: black;";
             css += "    padding: 5px 16px 5px 16px;";
             css += "    text-decoration: none;";
             css += "    display: block;";
             css += "}";
-            css += ".GClhdropdown-content-info {";
-            css += "    color: black;";
-            css += "    background-color: #ffffa5;";
-            css += "    padding: 5px 16px 5px 16px;";
-            css += "    text-decoration: none;";
-            css += "    display: none;";
-            css += "}";
-            css += ".GClhdropdown-content-layer:hover {";
+            css += ".FloppsMap-content-layer:hover {";
             css += "    background-color: #e1e1e1;";
             css += "    cursor: pointer;";
-            css += "}";
-            css += ".GClhdropdown-content-info:hover {";
-            css += "    background-color: #ffffa5;";
-            css += "    cursor: default;";
-            css += "}";
-            css += ".GClhdropdown:hover .GClhdropdown-content {";
-            css += "    display: block;";
             css += "}";
             css += "#ShowWaypointsOnFloppsMap_linklist{";
             css += "    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAAtVJREFUOBFdUktME1EUPW9+bYehsaV8SpGQCLgA/GAwRpdYFi7c1R0xMSHilsSFrli5YWX8xY2JLljY6MKFC01sQoyJCzBGS1QqMUGD0mIplOlnZt7zvinFhDPzZubd985995w7LJVKGcV8cbQar13hbUKDABy3Bk94UOhidMlbCAFV1fyhbDI3uB54FGmPLGnldJl5F7xLG+dLUyWzDB0qfooVYuD/oE8fCtCnHIVuG+h5FisT94NmwdKrwWosHyuhiC0HvKSnR56jz+r1Tw+oAaqGI6QHkfmRwXTuqnOkY1hHEDHJ1WqoMaq0GnJ1uNzCjiiJ051j6LV6fBm7ju0fbuohLBvLQBUIUVLJkVxNrpI8hTMBR/EYOJi9R3qzmsHEUhLHzHOow4HlGYCpsTy2EBNhEgT4CRpi5bQBxsg1QjQUxfX4DXQY7aiKGp78SdNW4vnL0qT9BP73/kNhfnKMdp/Eqe5RP87J1cK7Im6vLcEMkIQ97FXQOLEZlC2T+JL/ioVfbxHWW+EIF59LWVCTUBMOrTY4+xLktJmGk+sSuUIO0++ngDBNPBpkga53+X40ZTcSMKqPDiUf/e6riurnMnWTLAeOB8awwTfJuoqocEco0iPJITQSCGiuymnZFdQF4XJ6U6Mcj0qlvbIDO6zOK8ylqEsCqELi+AkcOHVUlGq43ALX9AybJXD34z0c1hPep+2sKsteQ94rK1W1TbTKn8qI2q2QHMnVrJQl6n/r812vDkXbI2FVqyvq/Z47FzFAdgl4Ea0XRa2s9q/Eecf3yAtucE8tKp5aY/OSK7UqqaEhrSU7YG5DCRlw2daEe/n3RP7Wt/512MLGYC6BxMvYzc5M6+M6NBEGr+wOrdjpbJY0HcRTqJOYbEmeTc4Mzo2IgblhMX5mfEbGQGsHt/tu+8FZ+rubiENNXU1phWThmgydeB17sPBw1V1cX5TNbGBWOgn8A8n0Lvks2/jiAAAAAElFTkSuQmCC)";

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -442,6 +442,8 @@ var variablesInit = function (c) {
     c.remove_navi_play = getValue("remove_navi_play", false);
     c.remove_navi_community = getValue("remove_navi_community", false);
     c.remove_navi_shop = getValue("remove_navi_shop", false);
+    c.settings_show_flopps_link = getValue("settings_show_flopps_link", true);
+    c.settings_show_brouter_link = getValue("settings_show_brouter_link", true);
 
     try {
         if (c.userToken === null) {
@@ -3305,7 +3307,7 @@ var mainGC = function () {
     appendCssStyle( css );
 
 // Show button, which open Flopp's Map with all waypoints of a cache and open Flopp's Map.
-    if (is_page("cache_listing") || document.location.href.match(/^https?:\/\/www\.geocaching\.com\/hide\/wptlist.aspx/)) {
+    if (settings_show_flopps_link && is_page("cache_listing") || document.location.href.match(/^https?:\/\/www\.geocaching\.com\/hide\/wptlist.aspx/)) {
         try {
             var css = "";
             css += ".FloppsMap-content-layer {";
@@ -3391,7 +3393,7 @@ var mainGC = function () {
     }
 
     // Show button, which open BRouter with all waypoints of a cache and open BRouter.
-    if (is_page("cache_listing") || document.location.href.match(/^https?:\/\/www\.geocaching\.com\/hide\/wptlist.aspx/)) {
+    if (settings_show_brouter_link && is_page("cache_listing") || document.location.href.match(/^https?:\/\/www\.geocaching\.com\/hide\/wptlist.aspx/)) {
         try {
 
             var css = ""; 
@@ -9344,6 +9346,8 @@ var mainGC = function () {
             }
             html += "</select> px" + show_help("With this option you can choose the height of the \"Add to list\" popup to bookmark a cache from 100 up to 520 pixel. The default is 205 pixel, similar to the standard.<br><br>This option requires \"Show compact layout in \"Add to list\" popup to bookmark a cache\".") + "<br>";
             html += newParameterVersionSetzen(0.8) + newParameterOff;
+            html += checkboxy('settings_show_flopps_link', 'Show Flopp\'s Map Links in Sidebar and under the Additional Waypoints') + show_help("If there are no additional Waypoints only the link in the Sidebar is shown.") + "<br/>";
+            html += checkboxy('settings_show_brouter_link', 'Show Link to BRouter in Sidebar and under the Additional Waypoints') + show_help("If there are no additional Waypoints only the link in the Sidebar is shown.") + "<br/>";
             html += "</div>";
 
             html += "<h4 class='gclh_headline2'>"+prepareHideable.replace("#name#","logging")+"Logging</h4>";
@@ -10305,7 +10309,9 @@ var mainGC = function () {
                 'settings_compact_layout_list_of_pqs',
                 'settings_compact_layout_nearest',
                 'settings_map_links_statistic',
-                'settings_improve_add_to_list'
+                'settings_improve_add_to_list',
+                'settings_show_flopps_link',
+                'settings_show_brouter_link'
             );
             for (var i = 0; i < checkboxes.length; i++) {
                 if ( document.getElementById(checkboxes[i]) ) {

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3319,8 +3319,15 @@ var mainGC = function () {
 
             var tbl = $('#ctl00_ContentBody_Waypoints');
             if ( tbl.length == 0 ) tbl = $('#ctl00_ContentBody_WaypointList');
-            tbl = tbl.next("p");
-            tbl.append('<div class="GClhdropdown"><div id="ShowWaypointsOnFloppsMap" class="GClhdropbtn"><a>Show waypoints on Flopp\'s Map with &#8230;</a></div><div id="FloppsMapLayers" class="GClhdropdown-content"></div></div>');
+
+            if(tbl.length == 0){
+                // We have no additional waypoint, so put the flopps links before the cache hints
+                tbl = $('#ctl00_ContentBody_hints');
+                tbl.before('<p><div class="GClhdropdown"><div id="ShowWaypointsOnFloppsMap" class="GClhdropbtn"><a>Show waypoints on Flopp\'s Map with &#8230;</a></div><div id="FloppsMapLayers" class="GClhdropdown-content"></div></div></p>');
+            }else{
+                tbl = tbl.next("p");
+                tbl.append('<div class="GClhdropdown"><div id="ShowWaypointsOnFloppsMap" class="GClhdropbtn"><a>Show waypoints on Flopp\'s Map with &#8230;</a></div><div id="FloppsMapLayers" class="GClhdropdown-content"></div></div>');
+            }
 
             $('#FloppsMapLayers').append('<div id="floppsmap-warning" class="GClhdropdown-content-info"><b>WARNING:</b> There are too many waypoints in the listing. Flopp\'s Map allows only a limited number of waypoints. Not all waypoints are shown.</div>');
 
@@ -3495,7 +3502,7 @@ var mainGC = function () {
         return addWP;
     }
 
-    // This function reads the table with the additional waypoints.
+    // This function reads the posted coordinates from the listing
     function getListingCoordinatesX() {
         var addWP  = [];
         try {

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3274,37 +3274,39 @@ var mainGC = function () {
         } catch( e ) { gclh_error( "Driving direction for Waypoints: ", e ); }
     }
 
-    var css = "";
-    css += ".GClhdropbtn {";
-    css += "    cursor: pointer;";
-    css += "}";
-    css += ".GClhdropdown {";
-    css += "    position: relative;";
-    css += "    display: inline-block;";
-    css += "}";
-    css += ".GClhdropdown-content {";
-    css += "    display: none;";
-    css += "    position: absolute;";
-    css += "    background-color: #f9f9f9;";
-    css += "    min-width: 160px;";
-    css += "    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);";
-    css += "    z-index: 1;";
-    css += "}";
-    css += ".GClhdropdown-content-info {";
-    css += "    color: black;";
-    css += "    background-color: #ffffa5;";
-    css += "    padding: 5px 16px 5px 16px;";
-    css += "    text-decoration: none;";
-    css += "    display: none;";
-    css += "}";
-    css += ".GClhdropdown-content-info:hover {";
-    css += "    background-color: #ffffa5;";
-    css += "    cursor: default;";
-    css += "}";
-    css += ".GClhdropdown:hover .GClhdropdown-content {";
-    css += "    display: block;";
-    css += "}";
-    appendCssStyle( css );
+    if(settings_show_brouter_link || settings_show_flopps_link){
+        var css = "";
+        css += ".GClhdropbtn {";
+        css += "    cursor: pointer;";
+        css += "}";
+        css += ".GClhdropdown {";
+        css += "    position: relative;";
+        css += "    display: inline-block;";
+        css += "}";
+        css += ".GClhdropdown-content {";
+        css += "    display: none;";
+        css += "    position: absolute;";
+        css += "    background-color: #f9f9f9;";
+        css += "    min-width: 160px;";
+        css += "    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);";
+        css += "    z-index: 1;";
+        css += "}";
+        css += ".GClhdropdown-content-info {";
+        css += "    color: black;";
+        css += "    background-color: #ffffa5;";
+        css += "    padding: 5px 16px 5px 16px;";
+        css += "    text-decoration: none;";
+        css += "    display: none;";
+        css += "}";
+        css += ".GClhdropdown-content-info:hover {";
+        css += "    background-color: #ffffa5;";
+        css += "    cursor: default;";
+        css += "}";
+        css += ".GClhdropdown:hover .GClhdropdown-content {";
+        css += "    display: block;";
+        css += "}";
+        appendCssStyle( css );
+    }
 
 // Show button, which open Flopp's Map with all waypoints of a cache and open Flopp's Map.
     if (settings_show_flopps_link && is_page("cache_listing") || document.location.href.match(/^https?:\/\/www\.geocaching\.com\/hide\/wptlist.aspx/)) {

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3372,12 +3372,12 @@ var mainGC = function () {
             tbl.append('<div class="GClhdropdown"><div id="ShowWaypointsOnBrouter" class="GClhdropbtn"><a>Calculate routing on BRouter with &#8230;</a></div><div id="BrouterMapLayers" class="GClhdropdown-content"></div></div>');
 			tbl.append('</p>');
 			
-            $('#BrouterMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OpenStreetMap">OpenStreetMap</div>');
-            $('#BrouterMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OpenStreetMap.de">OpenStreetMap.de</div>');
-            $('#BrouterMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OpenTopoMap">OpenTopoMap</div>');
-            $('#BrouterMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OpenCycleMap (Thunderf.)">OpenCycleMap</div>');
-            $('#BrouterMapLayers').append('<div class="GClhdropdown-content-layer" data-map="Outdoors (Thunderforest)">Outdoors</div>');
-            $('#BrouterMapLayers').append('<div class="GClhdropdown-content-layer" data-map="Esri World Imagery">Esri World Imagery</div>');
+            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenStreetMap">OpenStreetMap</div>');
+            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenStreetMap.de">OpenStreetMap.de</div>');
+            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenTopoMap">OpenTopoMap</div>');
+            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenCycleMap (Thunderf.)">OpenCycleMap</div>');
+            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="Outdoors (Thunderforest)">Outdoors</div>');
+            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="Esri World Imagery">Esri World Imagery</div>');
             
             var status = {};
             var waypoints = extractWaypointsFromListing();
@@ -3391,7 +3391,7 @@ var mainGC = function () {
             $('#ShowWaypointsOnBrouter').click( function() {
                 openBrouter("");
             });
-            $('.GClhdropdown-content-layer').click( function() {
+            $('.BRouter-content-layer').click( function() {
                 var map = $(this).data('map');
                 openBrouter(map);
             });

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3365,6 +3365,20 @@ var mainGC = function () {
     if (is_page("cache_listing") || document.location.href.match(/^https?:\/\/www\.geocaching\.com\/hide\/wptlist.aspx/)) {
         try {
 
+            var css = ""; 
+            css += ".BRouter-content-layer {"; 
+            css += "    color: black;"; 
+            css += "    padding: 5px 16px 5px 16px;"; 
+            css += "    text-decoration: none;"; 
+            css += "    display: block;"; 
+            css += "}";
+            css += ".BRouter-content-layer:hover {"; 
+            css += "    background-color: #e1e1e1;"; 
+            css += "    cursor: pointer;"; 
+            css += "}";
+            appendCssStyle( css ); 
+
+
             var tbl = $('#ctl00_ContentBody_Waypoints');
             if ( tbl.length == 0 ) tbl = $('#ctl00_ContentBody_WaypointList');
             tbl = tbl.next("p");

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3364,47 +3364,6 @@ var mainGC = function () {
     // Show button, which open BRouter with all waypoints of a cache and open BRouter.
     if (is_page("cache_listing") || document.location.href.match(/^https?:\/\/www\.geocaching\.com\/hide\/wptlist.aspx/)) {
         try {
-            var css = "";
-            css += ".GClhdropbtn {";
-            css += "    cursor: pointer;";
-            css += "}";
-            css += ".GClhdropdown {";
-            css += "    position: relative;";
-            css += "    display: inline-block;";
-            css += "}";
-            css += ".GClhdropdown-content {";
-            css += "    display: none;";
-            css += "    position: absolute;";
-            css += "    background-color: #f9f9f9;";
-            css += "    min-width: 160px;";
-            css += "    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);";
-            css += "    z-index: 1;";
-            css += "}";
-            css += ".GClhdropdown-content-layer {";
-            css += "    color: black;";
-            css += "    padding: 5px 16px 5px 16px;";
-            css += "    text-decoration: none;";
-            css += "    display: block;";
-            css += "}";
-            css += ".GClhdropdown-content-info {";
-            css += "    color: black;";
-            css += "    background-color: #ffffa5;";
-            css += "    padding: 5px 16px 5px 16px;";
-            css += "    text-decoration: none;";
-            css += "    display: none;";
-            css += "}";
-            css += ".GClhdropdown-content-layer:hover {";
-            css += "    background-color: #e1e1e1;";
-            css += "    cursor: pointer;";
-            css += "}";
-            css += ".GClhdropdown-content-info:hover {";
-            css += "    background-color: #ffffa5;";
-            css += "    cursor: default;";
-            css += "}";
-            css += ".GClhdropdown:hover .GClhdropdown-content {";
-            css += "    display: block;";
-            css += "}";
-            appendCssStyle( css );
 
             var tbl = $('#ctl00_ContentBody_Waypoints');
             if ( tbl.length == 0 ) tbl = $('#ctl00_ContentBody_WaypointList');

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3405,39 +3405,68 @@ var mainGC = function () {
             css += "    background-color: #e1e1e1;"; 
             css += "    cursor: pointer;"; 
             css += "}";
-            appendCssStyle( css ); 
+            css += "#ShowWaypointsOnBRouter_linklist{";
+            css += "    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAQCAYAAAAiYZ4HAAABG2lUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS41LjAiPgogPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIi8+CiA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgo8P3hwYWNrZXQgZW5kPSJyIj8+Gkqr6gAAAYJpQ0NQc1JHQiBJRUM2MTk2Ni0yLjEAACiRdZHLS0JBFIc/tSjUKMhFixYS1SIseoDUJkgJCyLEDLLa6M1H4ONyrxLSNmgrFERtei3qL6ht0DoIiiKIoF3rojYVt3NTUCLPcOZ885s5h5kzYA2nlYzeMAiZbF4LBXzuhciiu+kZOw5cQF9U0dWJYHCGuvZxh8WMN/1mrfrn/jXHSlxXwNIsPK6oWl54SnhmLa+avC3sUlLRFeFTYY8mFxS+NfVYmV9MTpb5y2QtHPKDtU3YnazhWA0rKS0jLC+nO5MuKJX7mC9xxrPzcxK7xDvRCRHAh5tpJvHjZYgxmb30M8yArKiTP/ibP0tOchWZVYporJIkRR6PqAWpHpeYED0uI03R7P/fvuqJkeFydacPGp8M460Hmrbgu2QYn4eG8X0Etke4yFbzcwcw+i56qap170PrBpxdVrXYDpxvQseDGtWiv5JN3JpIwOsJtESg/RrsS+WeVfY5vofwunzVFezuQa+cb13+ASNEZ8doe9nfAAAACXBIWXMAAC4jAAAuIwF4pT92AAACFklEQVQokW2Qy0tUYRjGf993vjnjbcaRcS7ljGZmOWlKnMmOmG0qGqTLRggkpDa1yHZB/0TgOohoE7TpsrE2SXbDTcpAkFFJNYkjORmmjqPneE4bZxqlZ/Xxvc/D+z4/QZn6+/tbuhvDD3Y7Kwm5kfesCU8uGVDne0Yevit6RPFhmmbLhZ7OiWtyJqS2fldslzsZyz3b5O9rHRl9CyCLgeSh9pFh72xIE5D+4/JVC1CjBJfiHvH6l/2k6JMAhmGIvXXV+zR7nafzGzhnrpLuHmQ6doSARyAKq0Hnxgm9fIMQW2f8tly6zF5M02TW1sorOgAKYHJy0unrNmao9SRSEYf7N6+ggrsYUFkcF/JaxZK89dze1mHq+9yrbONhu16XDAXXGeQbur3OxKKFLxR6nBqfDpd3GLIi8eHbGUuxQ+/zknta8+X8i9E35RsS/qHr+lRlFDvSXDJnCw4r8Tb0cxdxlpfiqfFpIQFEta9GCBEtHOjikdpTCoz9tPjQOwBCIDStAghLwzA8WjBcD6CiMZ4tK/BWYTmQ80WYr2sov7BdAgm9tb3E70dthM+NSV7mLHLJkyWn9Pmx5zJHJWDoHUagONA7ktzNKb5sekm3HS8FtEgDdjZjSqBVxZr3/5so0pbOp85TOKJEHRWNsbm4cFAJb2WVkLJpG8tjp/mobScs/XW4hbUGYRjGmBaNZ3fy/5/ctVX/X+/aoP1H+pyRAAAAAElFTkSuQmCC)";
+            css += "}";
+            appendCssStyle( css );
 
+            // Append the Brouter map to the right, top Linklist
+            var linklist_for_brouter = $('a[href^="/seek/gallery.aspx"]').parent().parent();
+
+            linklist_for_brouter.append('<li><div class="GClhdropdown"><a id="ShowWaypointsOnBRouter_linklist" href="#">Calculate routing on BRouter</a><div id="BrouterMapLayers_linklist" class="GClhdropdown-content"></div></div></li>');
+
+            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-info floppsmap-warning"><b>WARNING:</b> There are too many waypoints in the listing. Flopp\'s Map allows only a limited number of waypoints. Not all waypoints are shown.</div>');
+
+            $('#BrouterMapLayers_linklist').append('<div class="BRouter-content-layer" data-map="OpenStreetMap">OpenStreetMap</div>');
+            $('#BrouterMapLayers_linklist').append('<div class="BRouter-content-layer" data-map="OpenStreetMap.de">OpenStreetMap.de</div>');
+            $('#BrouterMapLayers_linklist').append('<div class="BRouter-content-layer" data-map="OpenTopoMap">OpenTopoMap</div>');
+            $('#BrouterMapLayers_linklist').append('<div class="BRouter-content-layer" data-map="OpenCycleMap (Thunderf.)">OpenCycleMap</div>');
+            $('#BrouterMapLayers_linklist').append('<div class="BRouter-content-layer" data-map="Outdoors (Thunderforest)">Outdoors</div>');
+            $('#BrouterMapLayers_linklist').append('<div class="BRouter-content-layer" data-map="Esri World Imagery">Esri World Imagery</div>');
+
+            $('#ShowWaypointsOnBRouter_linklist').click( function() {
+                    openBrouter("");
+            });
 
             var tbl = $('#ctl00_ContentBody_Waypoints');
             if ( tbl.length == 0 ) tbl = $('#ctl00_ContentBody_WaypointList');
-            tbl = tbl.next("p");
-            tbl.append('<p>');
-            tbl.append('<div class="GClhdropdown"><div id="ShowWaypointsOnBrouter" class="GClhdropbtn"><a>Calculate routing on BRouter with &#8230;</a></div><div id="BrouterMapLayers" class="GClhdropdown-content"></div></div>');
-			tbl.append('</p>');
-			
-            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenStreetMap">OpenStreetMap</div>');
-            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenStreetMap.de">OpenStreetMap.de</div>');
-            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenTopoMap">OpenTopoMap</div>');
-            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenCycleMap (Thunderf.)">OpenCycleMap</div>');
-            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="Outdoors (Thunderforest)">Outdoors</div>');
-            $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="Esri World Imagery">Esri World Imagery</div>');
             
-            var status = {};
-            var waypoints = extractWaypointsFromListing();
-            var link = buildBrouterMapLink( waypoints, 'OpenStreetMap', false, status );
+            if(tbl.length == 0){
+                // We have no additional waypoint, so the brouter link will not be displayed
+            }else{
+
+                tbl = tbl.next("p");
+                tbl.append('<p>');
+                tbl.append('<div class="GClhdropdown"><div id="ShowWaypointsOnBrouter" class="GClhdropbtn"><a>Calculate routing on BRouter with &#8230;</a></div><div id="BrouterMapLayers" class="GClhdropdown-content"></div></div>');
+    			tbl.append('</p>');
+    			
+                $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenStreetMap">OpenStreetMap</div>');
+                $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenStreetMap.de">OpenStreetMap.de</div>');
+                $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenTopoMap">OpenTopoMap</div>');
+                $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="OpenCycleMap (Thunderf.)">OpenCycleMap</div>');
+                $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="Outdoors (Thunderforest)">Outdoors</div>');
+                $('#BrouterMapLayers').append('<div class="BRouter-content-layer" data-map="Esri World Imagery">Esri World Imagery</div>');
+                
+                var status = {};
+                var waypoints = extractWaypointsFromListing();
+                var link = buildBrouterMapLink( waypoints, 'OpenStreetMap', false, status );
+
+
+                $('#ShowWaypointsOnBrouter').click( function() {
+                    openBrouter("");
+                });
+            }
+            
+            $('.BRouter-content-layer').click( function() {
+                var map = $(this).data('map');
+                openBrouter(map);
+            });
             
             function openBrouter( map ) {
                 var waypoints = extractWaypointsFromListing();
                 var link = buildBrouterMapLink( waypoints, map, false, {} );
                 window.open( link );
             }
-            $('#ShowWaypointsOnBrouter').click( function() {
-                openBrouter("");
-            });
-            $('.BRouter-content-layer').click( function() {
-                var map = $(this).data('map');
-                openBrouter(map);
-            });
         } catch( e ) { gclh_error("Show button BRouter and open BRouter", e); }
     }
 

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3352,7 +3352,7 @@ var mainGC = function () {
             if ( tbl.length == 0 ) tbl = $('#ctl00_ContentBody_WaypointList');
 
             if(tbl.length == 0){
-                // We have no additional waypoint, so the flops map will not be displayed
+                // We have no additional waypoints, so the flops map link will not be displayed in the listing
             }else{
                 tbl = tbl.next("p");
                 tbl.append('<div class="GClhdropdown"><div id="ShowWaypointsOnFloppsMap" class="GClhdropbtn"><a>Show waypoints on Flopp\'s Map with &#8230;</a></div><div id="FloppsMapLayers" class="GClhdropdown-content"></div></div>');
@@ -3436,7 +3436,7 @@ var mainGC = function () {
             if ( tbl.length == 0 ) tbl = $('#ctl00_ContentBody_WaypointList');
             
             if(tbl.length == 0){
-                // We have no additional waypoint, so the brouter link will not be displayed
+                // We have no additional waypoints, so the brouter link will not be displayed in the listing
             }else{
 
                 tbl = tbl.next("p");

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3331,14 +3331,14 @@ var mainGC = function () {
 
             $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-info floppsmap-warning"><b>WARNING:</b> There are too many waypoints in the listing. Flopp\'s Map allows only a limited number of waypoints. Not all waypoints are shown.</div>');
 
-            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="OSM">Openstreetmap</div>');
-            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="OSM/DE">German Style</div>');
-            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="OCM">OpenCycleMap</div>');
-            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="TOPO">OpenTopMap</div>');
-            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="roadmap">Google Maps</div>');
-            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="satellite">Google Maps Satellite</div>');
-            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="hybrid">Google Maps Hybrid</div>');
-            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="terrain">Google Maps Terrain</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="FloppsMap-content-layer" data-map="OSM">Openstreetmap</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="FloppsMap-content-layer" data-map="OSM/DE">German Style</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="FloppsMap-content-layer" data-map="OCM">OpenCycleMap</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="FloppsMap-content-layer" data-map="TOPO">OpenTopMap</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="FloppsMap-content-layer" data-map="roadmap">Google Maps</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="FloppsMap-content-layer" data-map="satellite">Google Maps Satellite</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="FloppsMap-content-layer" data-map="hybrid">Google Maps Hybrid</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="FloppsMap-content-layer" data-map="terrain">Google Maps Terrain</div>');
 
             $('#ShowWaypointsOnFloppsMap_linklist').click( function() {
                     openFloppsMap("");
@@ -3355,21 +3355,21 @@ var mainGC = function () {
 
                 $('#FloppsMapLayers').append('<div class="GClhdropdown-content-info floppsmap-warning"><b>WARNING:</b> There are too many waypoints in the listing. Flopp\'s Map allows only a limited number of waypoints. Not all waypoints are shown.</div>');
 
-                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OSM">Openstreetmap</div>');
-                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OSM/DE">German Style</div>');
-                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OCM">OpenCycleMap</div>');
-                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="TOPO">OpenTopMap</div>');
-                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="roadmap">Google Maps</div>');
-                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="satellite">Google Maps Satellite</div>');
-                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="hybrid">Google Maps Hybrid</div>');
-                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="terrain">Google Maps Terrain</div>');
+                $('#FloppsMapLayers').append('<div class="FloppsMap-content-layer" data-map="OSM">Openstreetmap</div>');
+                $('#FloppsMapLayers').append('<div class="FloppsMap-content-layer" data-map="OSM/DE">German Style</div>');
+                $('#FloppsMapLayers').append('<div class="FloppsMap-content-layer" data-map="OCM">OpenCycleMap</div>');
+                $('#FloppsMapLayers').append('<div class="FloppsMap-content-layer" data-map="TOPO">OpenTopMap</div>');
+                $('#FloppsMapLayers').append('<div class="FloppsMap-content-layer" data-map="roadmap">Google Maps</div>');
+                $('#FloppsMapLayers').append('<div class="FloppsMap-content-layer" data-map="satellite">Google Maps Satellite</div>');
+                $('#FloppsMapLayers').append('<div class="FloppsMap-content-layer" data-map="hybrid">Google Maps Hybrid</div>');
+                $('#FloppsMapLayers').append('<div class="FloppsMap-content-layer" data-map="terrain">Google Maps Terrain</div>');
                 
                 $('#ShowWaypointsOnFloppsMap').click( function() {
                     openFloppsMap("");
                 });
             }
 
-            $('.GClhdropdown-content-layer').click( function() {
+            $('.FloppsMap-content-layer').click( function() {
                 var map = $(this).data('map');
                 openFloppsMap(map);
             });

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3315,49 +3315,75 @@ var mainGC = function () {
             css += ".GClhdropdown:hover .GClhdropdown-content {";
             css += "    display: block;";
             css += "}";
+            css += "#ShowWaypointsOnFloppsMap_linklist{";
+            css += "    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAAtVJREFUOBFdUktME1EUPW9+bYehsaV8SpGQCLgA/GAwRpdYFi7c1R0xMSHilsSFrli5YWX8xY2JLljY6MKFC01sQoyJCzBGS1QqMUGD0mIplOlnZt7zvinFhDPzZubd985995w7LJVKGcV8cbQar13hbUKDABy3Bk94UOhidMlbCAFV1fyhbDI3uB54FGmPLGnldJl5F7xLG+dLUyWzDB0qfooVYuD/oE8fCtCnHIVuG+h5FisT94NmwdKrwWosHyuhiC0HvKSnR56jz+r1Tw+oAaqGI6QHkfmRwXTuqnOkY1hHEDHJ1WqoMaq0GnJ1uNzCjiiJ051j6LV6fBm7ju0fbuohLBvLQBUIUVLJkVxNrpI8hTMBR/EYOJi9R3qzmsHEUhLHzHOow4HlGYCpsTy2EBNhEgT4CRpi5bQBxsg1QjQUxfX4DXQY7aiKGp78SdNW4vnL0qT9BP73/kNhfnKMdp/Eqe5RP87J1cK7Im6vLcEMkIQ97FXQOLEZlC2T+JL/ioVfbxHWW+EIF59LWVCTUBMOrTY4+xLktJmGk+sSuUIO0++ngDBNPBpkga53+X40ZTcSMKqPDiUf/e6riurnMnWTLAeOB8awwTfJuoqocEco0iPJITQSCGiuymnZFdQF4XJ6U6Mcj0qlvbIDO6zOK8ylqEsCqELi+AkcOHVUlGq43ALX9AybJXD34z0c1hPep+2sKsteQ94rK1W1TbTKn8qI2q2QHMnVrJQl6n/r812vDkXbI2FVqyvq/Z47FzFAdgl4Ea0XRa2s9q/Eecf3yAtucE8tKp5aY/OSK7UqqaEhrSU7YG5DCRlw2daEe/n3RP7Wt/512MLGYC6BxMvYzc5M6+M6NBEGr+wOrdjpbJY0HcRTqJOYbEmeTc4Mzo2IgblhMX5mfEbGQGsHt/tu+8FZ+rubiENNXU1phWThmgydeB17sPBw1V1cX5TNbGBWOgn8A8n0Lvks2/jiAAAAAElFTkSuQmCC)";
+            css += "}";
+
             appendCssStyle( css );
+
+            // Append the Flopps map to the right, top Linklist
+            var linklist_for_flopps = $('a[href^="/seek/gallery.aspx"]').parent().parent();
+
+            linklist_for_flopps.append('<li><div class="GClhdropdown"><a id="ShowWaypointsOnFloppsMap_linklist" href="#">Show on Flopp\'s Map</a><div id="FloppsMapLayers_linklist" class="GClhdropdown-content"></div></div></li>');
+
+            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-info floppsmap-warning"><b>WARNING:</b> There are too many waypoints in the listing. Flopp\'s Map allows only a limited number of waypoints. Not all waypoints are shown.</div>');
+
+            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="OSM">Openstreetmap</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="OSM/DE">German Style</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="OCM">OpenCycleMap</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="TOPO">OpenTopMap</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="roadmap">Google Maps</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="satellite">Google Maps Satellite</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="hybrid">Google Maps Hybrid</div>');
+            $('#FloppsMapLayers_linklist').append('<div class="GClhdropdown-content-layer" data-map="terrain">Google Maps Terrain</div>');
+
+            $('#ShowWaypointsOnFloppsMap_linklist').click( function() {
+                    openFloppsMap("");
+            });
 
             var tbl = $('#ctl00_ContentBody_Waypoints');
             if ( tbl.length == 0 ) tbl = $('#ctl00_ContentBody_WaypointList');
 
             if(tbl.length == 0){
-                // We have no additional waypoint, so put the flopps links before the cache hints
-                tbl = $('#ctl00_ContentBody_hints');
-                tbl.before('<p><div class="GClhdropdown"><div id="ShowWaypointsOnFloppsMap" class="GClhdropbtn"><a>Show waypoints on Flopp\'s Map with &#8230;</a></div><div id="FloppsMapLayers" class="GClhdropdown-content"></div></div></p>');
+                // We have no additional waypoint, so the flops map will not be displayed
             }else{
                 tbl = tbl.next("p");
                 tbl.append('<div class="GClhdropdown"><div id="ShowWaypointsOnFloppsMap" class="GClhdropbtn"><a>Show waypoints on Flopp\'s Map with &#8230;</a></div><div id="FloppsMapLayers" class="GClhdropdown-content"></div></div>');
+
+                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-info floppsmap-warning"><b>WARNING:</b> There are too many waypoints in the listing. Flopp\'s Map allows only a limited number of waypoints. Not all waypoints are shown.</div>');
+
+                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OSM">Openstreetmap</div>');
+                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OSM/DE">German Style</div>');
+                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OCM">OpenCycleMap</div>');
+                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="TOPO">OpenTopMap</div>');
+                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="roadmap">Google Maps</div>');
+                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="satellite">Google Maps Satellite</div>');
+                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="hybrid">Google Maps Hybrid</div>');
+                $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="terrain">Google Maps Terrain</div>');
+                
+                $('#ShowWaypointsOnFloppsMap').click( function() {
+                    openFloppsMap("");
+                });
             }
 
-            $('#FloppsMapLayers').append('<div id="floppsmap-warning" class="GClhdropdown-content-info"><b>WARNING:</b> There are too many waypoints in the listing. Flopp\'s Map allows only a limited number of waypoints. Not all waypoints are shown.</div>');
-
-            $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OSM">Openstreetmap</div>');
-            $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OSM/DE">German Style</div>');
-            $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="OCM">OpenCycleMap</div>');
-            $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="TOPO">OpenTopMap</div>');
-            $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="roadmap">Google Maps</div>');
-            $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="satellite">Google Maps Satellite</div>');
-            $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="hybrid">Google Maps Hybrid</div>');
-            $('#FloppsMapLayers').append('<div class="GClhdropdown-content-layer" data-map="terrain">Google Maps Terrain</div>');
+            $('.GClhdropdown-content-layer').click( function() {
+                var map = $(this).data('map');
+                openFloppsMap(map);
+            });
 
             var status = {};
             var waypoints = extractWaypointsFromListing();
             var link = buildFloppsMapLink( waypoints, 'OSM', false, status );
-            if ( status.limited == true ) $("#floppsmap-warning").show();
-            else $("#floppsmap-warning").hide();
 
             function openFloppsMap( map ) {
                 var waypoints = extractWaypointsFromListing();
                 var link = buildFloppsMapLink( waypoints, map, false, {} );
                 window.open( link );
             }
-            $('#ShowWaypointsOnFloppsMap').click( function() {
-                openFloppsMap("");
-            });
-            $('.GClhdropdown-content-layer').click( function() {
-                var map = $(this).data('map');
-                openFloppsMap(map);
-            });
+
+            if ( status.limited == true ) $(".floppsmap-warning").show();
+            else $(".floppsmap-warning").hide();
+
         } catch( e ) { gclh_error("Show button Flopp's Map and open Flopp's Map", e); }
     }
 


### PR DESCRIPTION
Ich habe über die BRouter Funktion geschaut und ein paar Anpassungen für das CSS gemacht. Ansonsten finde ich die Funktion toll. Das kannte ich bisher nicht 😉 (fixes #425). Weiterhin gibt es jetzt Links für BRouter und Flopps in der Sidebar und man kann beides (separat) in der Konfig aus- bzw. einschalten (Im Konfig Bereich unter Listing) (fixes #294, fixes #308).
Zu #297 : der Link zu Flopps ist nun in der Sidebar, auch wenn es keine zusätzlichen Waypoints gibt (fixes #297).