### PR TITLE
 Added a new function: active select date into geocaches and travelbugs calendar

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -2139,77 +2139,6 @@ var mainGC = function() {
         return waypoint;
     }
 
- // Add select date into calendar
-
-    function onChangeCalendarSelect(event) {
-
-        const selectedYear = $("#selectYearEl").val();
-        const selectedMonth = $("#selectMonthEl").val();
-
-        const ONE_DAY = 1000 * 60 * 60 * 24;
-        const GC_ERA_MS = new Date(2000, 0, 2).getTime();
-
-        const selectedDate = new Date(selectedYear, selectedMonth, 1);
-        const difference_ms = Math.abs(selectedDate.getTime() - GC_ERA_MS);
-        const daysFromGCEra = Math.round(difference_ms/ONE_DAY) + 1;
-
-        // "__doPostBack" is function from GC.COM
-        __doPostBack('ctl00$ContentBody$MyCalendar', 'V'+daysFromGCEra);
-    }
-
-    function appendOptionalEl(selectEl, value, text, isSelected) {
-
-        const optEl = document.createElement("OPTION");
-        optEl.setAttribute("value", value);
-
-        if( isSelected ) {
-            optEl.setAttribute("selected", "selected");
-        }
-
-        const textNode = document.createTextNode(text);
-        optEl.appendChild(textNode);
-
-        selectEl.appendChild(optEl);
-    }
-
-    if (is_page("geocaches") || is_page("travelbugs")) {
-        try {
-
-            const selectYearEl = document.createElement("SELECT");
-            selectYearEl.id = 'selectYearEl';
-            selectYearEl.onchange = onChangeCalendarSelect;
-
-            const selectMonthEl = document.createElement("SELECT");
-            selectMonthEl.id = 'selectMonthEl';
-            selectMonthEl.onchange = onChangeCalendarSelect;
-
-            var calendarHeaderElements = $("#ctl00_ContentBody_MyCalendar").find("tbody tr:first td table tbody tr td:nth-child(2)");
-            if( calendarHeaderElements.length > 0 ) {
-                var selectedCalendar = calendarHeaderElements.text().split(" ");
-                var CURRENT_YEAR = selectedCalendar[0];
-                var CURRENT_MONTH = selectedCalendar[1];
-
-                calendarHeaderElements.empty(); // Clean header content
-                calendarHeaderElements.append(selectYearEl);
-                calendarHeaderElements.append(selectMonthEl);
-
-                const LAST_YEAR = new Date().getFullYear();
-                for(var year = 2000; year <= LAST_YEAR; year++) {
-                    appendOptionalEl(selectYearEl, year, year, (year == CURRENT_YEAR));
-                }
-
-                for(var month = 0; month < 12; month++) {
-                    var objDate = new Date();
-                    objDate.setMonth(month);
-                    var locale = "en-us"; // TODO load from user settings, but if you change, must determinate witch month is selected
-                    var monthText = objDate.toLocaleString(locale, { month: "long" });
-                    appendOptionalEl(selectMonthEl, month, monthText, (monthText == CURRENT_MONTH));
-                }
-            }
-
-        } catch(e) {gclh_error("Add select date into calendar: ",e);}
-    }
-
 // Hide greenToTopButton.
     if (settings_hide_top_button) $("#topScroll").attr("id", "_topScroll").hide();
 
@@ -6464,6 +6393,77 @@ var mainGC = function() {
                 }
             } catch(e) {gclh_error("Stopped logs loading:",e);}
         }
+    }
+
+// Add select date into calendar
+
+    function onChangeCalendarSelect(event) {
+
+        const selectedYear = $("#selectYearEl").val();
+        const selectedMonth = $("#selectMonthEl").val();
+
+        const ONE_DAY = 1000 * 60 * 60 * 24;
+        const GC_ERA_MS = new Date(2000, 0, 2).getTime();
+
+        const selectedDate = new Date(selectedYear, selectedMonth, 1);
+        const difference_ms = Math.abs(selectedDate.getTime() - GC_ERA_MS);
+        const daysFromGCEra = Math.round(difference_ms/ONE_DAY) + 1;
+
+        // "__doPostBack" is function from GC.COM
+        __doPostBack('ctl00$ContentBody$MyCalendar', 'V'+daysFromGCEra);
+    }
+
+    function appendOptionalEl(selectEl, value, text, isSelected) {
+
+        const optEl = document.createElement("OPTION");
+        optEl.setAttribute("value", value);
+
+        if( isSelected ) {
+            optEl.setAttribute("selected", "selected");
+        }
+
+        const textNode = document.createTextNode(text);
+        optEl.appendChild(textNode);
+
+        selectEl.appendChild(optEl);
+    }
+
+    if (is_page("geocaches") || is_page("travelbugs")) {
+        try {
+
+            const selectYearEl = document.createElement("SELECT");
+            selectYearEl.id = 'selectYearEl';
+            selectYearEl.onchange = onChangeCalendarSelect;
+
+            const selectMonthEl = document.createElement("SELECT");
+            selectMonthEl.id = 'selectMonthEl';
+            selectMonthEl.onchange = onChangeCalendarSelect;
+
+            var calendarHeaderElements = $("#ctl00_ContentBody_MyCalendar").find("tbody tr:first td table tbody tr td:nth-child(2)");
+            if( calendarHeaderElements.length > 0 ) {
+                var selectedCalendar = calendarHeaderElements.text().split(" ");
+                var CURRENT_YEAR = selectedCalendar[0];
+                var CURRENT_MONTH = selectedCalendar[1];
+
+                calendarHeaderElements.empty(); // Clean header content
+                calendarHeaderElements.append(selectYearEl);
+                calendarHeaderElements.append(selectMonthEl);
+
+                const LAST_YEAR = new Date().getFullYear();
+                for(var year = 2000; year <= LAST_YEAR; year++) {
+                    appendOptionalEl(selectYearEl, year, year, (year == CURRENT_YEAR));
+                }
+
+                for(var month = 0; month < 12; month++) {
+                    var objDate = new Date();
+                    objDate.setMonth(month);
+                    var locale = "en-us"; // maybe load from user settings, but if you change, must determinate witch month is selected
+                    var monthText = objDate.toLocaleString(locale, { month: "long" });
+                    appendOptionalEl(selectMonthEl, month, monthText, (monthText == CURRENT_MONTH));
+                }
+            }
+
+        } catch(e) {gclh_error("Add select date into calendar: ",e);}
     }
 
 // Show warning for not available images.

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -6428,7 +6428,7 @@ var mainGC = function() {
         selectEl.appendChild(optEl);
     }
 
-    if (is_page("geocaches") || is_page("travelbugs")) {
+    if (document.location.href.match(/\.com\/my\/geocaches\.aspx/) || document.location.href.match(/\.com\/my\/travelbugs\.aspx/)) {
         try {
 
             const selectYearEl = document.createElement("SELECT");
@@ -10756,12 +10756,6 @@ function getValue(name, defaultValue) {
 function is_link(name, url) {
     var status = false;
     switch (name) {
-        case "geocaches":
-            if (url.match(/\.com\/my\/geocaches\.aspx/)) status = true;
-            break;
-        case "travelbugs":
-            if (url.match(/\.com\/my\/travelbugs\.aspx/)) status = true;
-            break;
         case "cache_listing":
             if (url.match(/\.com\/(seek\/cache_details\.aspx|geocache\/)/) && !document.getElementById("cspSubmit") && !document.getElementById("cspGoBack")) status = true;
             break;

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -2177,7 +2177,7 @@ var mainGC = function() {
     if ((is_page("geocaches") && settings_select_geocaches_calendar) || (is_page("travelbugs") && settings_select_trackables_calendar)) {
         try {
 
-        	const selectYearEl = document.createElement("SELECT");
+            const selectYearEl = document.createElement("SELECT");
             selectYearEl.id = 'selectYearEl';
             selectYearEl.onchange = onChangeCalendarSelect;
 
@@ -2195,18 +2195,18 @@ var mainGC = function() {
                 calendarHeaderElements.append(selectYearEl);
                 calendarHeaderElements.append(selectMonthEl);
 
-	            const LAST_YEAR = new Date().getFullYear();
-	            for(var year = 2000; year <= LAST_YEAR; year++) {
-	                appendOptionalEl(selectYearEl, year, year, (year == CURRENT_YEAR));
-	            }
+                const LAST_YEAR = new Date().getFullYear();
+                for(var year = 2000; year <= LAST_YEAR; year++) {
+                    appendOptionalEl(selectYearEl, year, year, (year == CURRENT_YEAR));
+                }
 
-	            for(var month = 0; month < 12; month++) {
-	                var objDate = new Date();
-	                objDate.setMonth(month);
-	                var locale = "en-us"; // TODO load from user settings, but if you change, must determinate witch month is selected
-	                var monthText = objDate.toLocaleString(locale, { month: "long" });
-	                appendOptionalEl(selectMonthEl, month, monthText, (monthText == CURRENT_MONTH));
-	            }
+                for(var month = 0; month < 12; month++) {
+                    var objDate = new Date();
+                    objDate.setMonth(month);
+                    var locale = "en-us"; // TODO load from user settings, but if you change, must determinate witch month is selected
+                    var monthText = objDate.toLocaleString(locale, { month: "long" });
+                    appendOptionalEl(selectMonthEl, month, monthText, (monthText == CURRENT_MONTH));
+                }
             }
 
         } catch(e) {gclh_error("Add select date into calendar: ",e);}
@@ -8329,7 +8329,7 @@ var mainGC = function() {
             html += " &nbsp; " + checkboxy('settings_remove_message_in_header', 'Remove message center icon top right') + show_help_big("With this option you can remove the message center icon top right on GC pages. You will not be informed longer about new messages.<br><br>" + t_reqChl) + "<br>";
             html += " &nbsp; " + checkboxy('settings_gc_tour_is_working', 'Reserve a place for GC Tour icon') + show_help("If the script GC Tour is running, you can reserve a place top left on GC pages for the GC Tour icon.<br><br>" + t_reqChl) + "<br>";
             html += " &nbsp; " + checkboxy('settings_fixed_header_layout', 'Arrange header layout on content') + show_help_big("With this option you can arrange the header width on the width of the content of GC pages. This is an easy feature with some restrictions, like for example the available place, especially for horizontal navigation menues.<br><br>This feature is available on GC pages in the oldest design like for example cache and TB listings, bookmarks, pocket queries, nearest lists, old dashboards (profiles), statistics, watchlists and drafts, to name just a few. <br><br>On map page and on pages in the newer and newest design it is not available, partly because the content on these pages are not yet in an accurate width, like the newer search cache page or the message center page. Also this feature is not fully integrated in the diverse possibilities of the header layout and the navigation menus. But we hope the friends of this specific header design can deal with it.<br><br>" + t_reqChl) + "<br>";
-			html += checkboxy('settings_bookmarks_on_top', "Show <a class='gclh_ref' href='#gclh_linklist' title='Link to topic \"Linklist / Navigation\"' id='gclh_linklist_link_1'>Linklist</a> on top") + show_help_big("Show the Linklist on the top of GC pages, beside the other links. You can configure the links in the Linklist at the end of this configuration page.<br><br>Some of the features of the Linklist on top, like for example the font size or the distance between drop-down links, requires \"Change header layout\". Details you can see at the end of this configuration page by the features of the Linklist.") + "<br>";
+            html += checkboxy('settings_bookmarks_on_top', "Show <a class='gclh_ref' href='#gclh_linklist' title='Link to topic \"Linklist / Navigation\"' id='gclh_linklist_link_1'>Linklist</a> on top") + show_help_big("Show the Linklist on the top of GC pages, beside the other links. You can configure the links in the Linklist at the end of this configuration page.<br><br>Some of the features of the Linklist on top, like for example the font size or the distance between drop-down links, requires \"Change header layout\". Details you can see at the end of this configuration page by the features of the Linklist.") + "<br>";
             html += checkboxy('settings_hide_advert_link', 'Hide link to advertisement instructions') + "<br>";
             html += "&nbsp;" + "Page width: <input class='gclh_form' type='text' size='4' id='settings_new_width' value='" + getValue("settings_new_width", 1000) + "'> px" + show_help("With this option you can expand the small layout on GC pages. The default value on GC pages is 950 pixel.") + "<br>";
             html += checkboxy('settings_hide_facebook', 'Hide Facebook login') + "<br>";
@@ -10667,7 +10667,7 @@ var mainGC = function() {
                         setValue("settings_sync_last", settings_sync_last.toString()).done(function() {
                             setValue("settings_sync_hash", settings_sync_hash).done(function() {
                                 if (is_page("profile")) reloadPage();
-    						});
+                            });
                         });
                     });
                 }
@@ -10746,7 +10746,7 @@ function setValue(name, value) {
 }
 function setValueSet(data) {
     var defer = $.Deferred();
-	var data2Store = {};
+    var data2Store = {};
     for (key in data) {
         CONFIG[key] = data[key];
         data2Store[key] = data[key];
@@ -10766,14 +10766,14 @@ function getValue(name, defaultValue) {
 
 // Auf welcher Seite bin ich?
 function is_link(name, url) {
-	var status = false;
+    var status = false;
     switch (name) {
-	    case "geocaches":
-	        if (url.match(/\.com\/my\/geocaches\.aspx/)) status = true;
-	        break;
-	    case "travelbugs":
-	        if (url.match(/\.com\/my\/travelbugs\.aspx/)) status = true;
-	        break;
+        case "geocaches":
+            if (url.match(/\.com\/my\/geocaches\.aspx/)) status = true;
+            break;
+        case "travelbugs":
+            if (url.match(/\.com\/my\/travelbugs\.aspx/)) status = true;
+            break;
         case "cache_listing":
             if (url.match(/\.com\/(seek\/cache_details\.aspx|geocache\/)/) && !document.getElementById("cspSubmit") && !document.getElementById("cspGoBack")) status = true;
             break;
@@ -10859,7 +10859,4 @@ function getDateDiffString(dateNew, dateOld) {
     return strDateDiff;
 }
 
-
-
 start(this);
-

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -463,8 +463,6 @@ var variablesInit = function(c) {
     c.settings_show_bigger_avatars_but = getValue("settings_show_bigger_avatars_but", true);
     c.settings_hide_feedback_icon = getValue("settings_hide_feedback_icon", false);
     c.settings_compact_layout_new_dashboard = getValue("settings_compact_layout_new_dashboard", false);
-    c.settings_select_trackables_calendar = getValue("settings_select_trackables_calendar", true);
-    c.settings_select_geocaches_calendar = getValue("settings_select_geocaches_calendar", true);
 
     try {
         if (c.userToken === null) {
@@ -2174,7 +2172,7 @@ var mainGC = function() {
         selectEl.appendChild(optEl);
     }
 
-    if ((is_page("geocaches") && settings_select_geocaches_calendar) || (is_page("travelbugs") && settings_select_trackables_calendar)) {
+    if (is_page("geocaches") || is_page("travelbugs")) {
         try {
 
             const selectYearEl = document.createElement("SELECT");
@@ -8343,9 +8341,6 @@ var mainGC = function() {
             html += " &nbsp; " + checkboxy('settings_remove_banner_for_garminexpress', 'for \"Garmin Express\"') + "<br>";
             html += " &nbsp; " + checkboxy('settings_remove_banner_blue', 'Try to remove all blue banner to new designed pages') + "<br>";
             html += newParameterVersionSetzen(0.8) + newParameterOff;
-            html += newParameterOn3;
-            html += checkboxy('settings_select_geocaches_calendar', 'Select date in geocaches calendar') + show_help("Allows to switch year and month in the geocaches calendar.") + "<br>";
-            html += newParameterVersionSetzen(0.9) + newParameterOff;
             html += "<table style='width: 550px; text-align: left; margin-top: 9px;'>";
             html += "  <thead>";
             html += "    <tr><th><span>Show lines in</span></th>";
@@ -8587,9 +8582,6 @@ var mainGC = function() {
             html += "<div id='gclh_config_profile' class='gclh_block'>";
             html += "<div style='margin-left: 5px'><b>Trackables</b></div>";
             html += checkboxy('settings_faster_profile_trackables', 'Load trackables faster without images') + show_help("With this option you can stop the load on the trackable pages after the necessary datas are loaded. You disclaim of the lengthy load of the images of the trackables. This procedure is much faster as load all datas, because every image is loaded separate and not in a bigger bundle like it is for the non image data.") + "<br>";
-            html += newParameterOn3;
-            html += checkboxy('settings_select_trackables_calendar', 'Select date in trackables calendar') + show_help("Allows to switch year and month in the trackables calendar.") + "<br>";
-            html += newParameterVersionSetzen(0.9) + newParameterOff;
             html += "<div style='margin-top: 9px; margin-left: 5px'><b>Gallery</b></div>";
             var content_settings_show_thumbnails = checkboxy('settings_show_thumbnails', 'Show thumbnails of images') + show_help_big("With this option the images are displayed as thumbnails to have a preview. If you hover with your mouse over a thumbnail, you can see the big one.<br><br>This works in cache and TB logs, in the cache and TB image galleries, in public profile for the avatar and in the profile image gallery. <br><br>And after pressing button \"Show bigger avatars\" in cache listing, it works too for the avatars in the shown logs.") + "&nbsp; Max size of big image: <input class='gclh_form' size=3 type='text' id='settings_hover_image_max_size' value='" + settings_hover_image_max_size + "'> px <br>";
             html += content_settings_show_thumbnails;
@@ -9506,8 +9498,6 @@ var mainGC = function() {
             setValue("settings_pq_terrain", document.getElementById('settings_pq_terrain').value);
             setValue("settings_pq_terrain_score", document.getElementById('settings_pq_terrain_score').value);
             setValue("settings_improve_add_to_list_height", document.getElementById('settings_improve_add_to_list_height').value);
-            setValue("settings_select_trackables_calendar", document.getElementById('settings_select_trackables_calendar').value);
-            setValue("settings_select_geocaches_calendar", document.getElementById('settings_select_geocaches_calendar').value);
 
             // Map Layers in vorgegebener Reihenfolge übernehmen.
             var new_map_layers_available = document.getElementById('settings_maplayers_available');
@@ -9709,9 +9699,7 @@ var mainGC = function() {
                 'settings_show_log_counter_but',
                 'settings_show_bigger_avatars_but',
                 'settings_hide_feedback_icon',
-                'settings_compact_layout_new_dashboard',
-                'settings_select_trackables_calendar',
-                'settings_select_geocaches_calendar'
+                'settings_compact_layout_new_dashboard'
             );
             for (var i = 0; i < checkboxes.length; i++) {
                 if (document.getElementById(checkboxes[i])) setValue(checkboxes[i], document.getElementById(checkboxes[i]).checked);


### PR DESCRIPTION
Did you ever browse the calendar? Year or two back? GC provides scrolling by only one month. Very slow browsing.

This new feature adds two selections to the calendar. You can quickly select a year or a month.

Here is result: 
![calendar_with_active_select](https://user-images.githubusercontent.com/10053527/34965051-9a3dc532-fa51-11e7-8fc0-df2737e2bb55.png)
