### PR TITLE
#671 show elevation 0m without plus sign. negative values are shown c…

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -2098,7 +2098,7 @@ var mainGC = function() {
     if (settings_show_elevation_of_waypoints && is_page("cache_listing") && !isMemberInPmoCache()) {
         try {
             function formatElevation(elevation) {
-                return ((elevation>=0)?"+":"")+((settings_distance_units != "Imperial")?(Math.round(elevation) + "m"):(Math.round(elevation*3.28084) + "ft"));
+                return ((elevation>0)?"+":"")+((settings_distance_units != "Imperial")?(Math.round(elevation) + "m"):(Math.round(elevation*3.28084) + "ft"));
             }
             elevationServicesData[1]['function'] = addElevationToWaypoints_GoogleElevation;
             elevationServicesData[2]['function'] = addElevationToWaypoints_OpenElevation;


### PR DESCRIPTION
…orrectly because the minus sign comes with the value (with both elevation services). For positive values the plus sign is added.