### PR TITLE
fix #670: check if the coordinates of a waypoint is unknown

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -2154,7 +2154,8 @@ var mainGC = function() {
                     json = JSON.parse(responseDetails.responseText);
                     var elevations = [];
                     for (var i=0; i<json.results.length; i++) {
-                        elevations.push( json.results[i].elevation );
+                        if (json.results[i].latitude != -90) elevations.push(json.results[i].elevation);
+                        else elevations.push(undefined);                                              
                     }
                     addElevationToWaypoints(elevations,context);
                 } catch(e) {gclh_error("addElevationToWaypoints_OpenElevation():",e);}


### PR DESCRIPTION
Please review. 

The elevation of waypoints with unknown coordinates are now marked with "n/a"