### PR TITLE
Show both tabs "Active Pocket Queries" and "Pocket Queries Ready for Download" together of one page. #835

### DIFF
--- a/data/config_standard.txt
+++ b/data/config_standard.txt
@@ -232,5 +232,6 @@
   "settings_show_enhanced_map_popup": true,
   "settings_gclherror_alert": false,
   "settings_auto_open_tb_inventory_list": true,
-  "settings_embedded_smartlink_ignorelist": true
+  "settings_embedded_smartlink_ignorelist": true,
+  "settings_both_tabs_list_of_pqs_one_page": false
 }


### PR DESCRIPTION
config_standard.txt angepaßt