### PR TITLE
Save Personal Cache Note in cache listing with F2 key #907

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -1123,6 +1123,12 @@ var mainGC = function() {
                 else if ($('#ctl00_ContentBody_Attributes_btnUpdate')[0]) var id = "ctl00_ContentBody_Attributes_btnUpdate";
                 else if ($('#ctl00_ContentBody_WaypointEdit_uxSubmitIt')[0]) var id = "ctl00_ContentBody_WaypointEdit_uxSubmitIt";
             }
+            // "Save" Personal Cache Note in cache listing.
+            if (is_page("cache_listing") && $('.js-pcn-submit')[0]) {
+                var id = "gclh_js-pcn-submit";
+                $('.js-pcn-submit')[0].id = id;
+                document.getElementById(id).innerHTML += " (F2)";
+            }
             if (id && document.getElementById(id)) {
                 function keydownF2(e) {
                     if (e.keyCode == 113 && noSpecialKey(e) && !check_config_page()) document.getElementById(id).click();
@@ -9803,7 +9809,7 @@ var mainGC = function() {
             html += "<div id='gclh_config_pq' class='gclh_block'>";
             html += checkboxy('settings_fixed_pq_header', 'Show fixed header in list of pocket queries') + show_help("With this option the header in list of pocket queries is fixed and the list of pocket queries can be scrolled.<br><br>This option evolute its effect not with the compact layout in list of pocket queries.") + "<br>";
             html += content_settings_show_log_it.replace("show_log_it","show_log_itX0");
-            var content_settings_submit_log_button = checkboxy('settings_submit_log_button', 'Submit log, pocket query, bookmark or hide cache on F2') + show_help("With this option you are able to submit your log by pressing key F2 instead of scrolling to the bottom and move the mouse to the button. <br><br>This feature also works to submit pocket queries and bookmarks. <br><br>And it works on the whole hide cache process with all of the buttons of the create and the change functionality.") + "<br>";
+            var content_settings_submit_log_button = checkboxy('settings_submit_log_button', 'Submit log, pocket query, bookmark or hide cache on F2') + show_help("With this option you are able to submit your log by pressing key F2 instead of scrolling to the bottom and move the mouse to the button. <br><br>This feature also works to submit pocket queries and bookmarks. <br><br>And it works on the whole hide cache process with all of the buttons of the create and the change functionality. <br><br>It works also to save Personal Cache Notes in cache listings.") + "<br>";
             html += content_settings_submit_log_button;
             html += newParameterOn2;
             html += checkboxy('settings_compact_layout_list_of_pqs', 'Show compact layout in list of pocket queries') + "<br>";


### PR DESCRIPTION
Getestet für mögliche Kombinationen der Parameter
- Hide Personal Cache Notes if empty
- Hide Personal Cache Notes completely

Getestet wenn F2 Key abgeschaltet.
Helptext wurde ergänzt.