### PR TITLE
Hide DNF smileys by default in browse map (old map)  #1115

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -401,7 +401,7 @@ var variablesInit = function(c) {
     c.settings_highlight_usercoords_it = getValue('settings_highlight_usercoords_it', true);
     c.settings_map_hide_found = getValue('settings_map_hide_found', true);
     c.settings_map_hide_hidden = getValue('settings_map_hide_hidden', true);
-    c.settings_map_DNF_removeSmileys = getValue('settings_map_DNF_removeSmileys', true);
+    c.settings_map_hide_dnfs = getValue('settings_map_hide_dnfs', true);
     c.settings_map_hide_2 = getValue('settings_map_hide_2', false);
     c.settings_map_hide_9 = getValue('settings_map_hide_9', false);
     c.settings_map_hide_5 = getValue('settings_map_hide_5', false);
@@ -7277,7 +7277,7 @@ var mainGC = function() {
                 var button = unsafeWindow.document.getElementById("m_myCaches").childNodes[5];
                 if (button) button.click();
             }
-            if (settings_map_DNF_removeSmileys) isMapLoad(removeDNFSmileys);
+            if (settings_map_hide_dnfs) isMapLoad(removeDNFSmileys);
             function getAllCachetypeButtons(){
                 return ['Legend2', 'Legend9', 'Legend3', 'Legend6', 'Legend13', 'Legend453', 'Legend7005', 'Legend1304', 'Legend137', 'Legend4', 'Legend11', 'Legend8', 'Legend5', 'Legend1858'];
             }
@@ -10480,7 +10480,7 @@ var mainGC = function() {
             html += checkboxy('settings_map_hide_found', 'Hide found caches by default') + prem + "<br>";
             html += checkboxy('settings_map_hide_hidden', 'Hide own caches by default') + prem + "<br>";
             html += newParameterOn1;
-            html += checkboxy('settings_map_DNF_removeSmileys', 'Remove DNF smileys by default') + prem + "<br>";
+            html += checkboxy('settings_map_hide_dnfs', 'Hide DNF smileys by default') + prem + "<br>";
             html += newParameterVersionSetzen('0.10') + newParameterOff;
             html += "&nbsp;" + "Hide cache types by default: " + prem + "<br>";
 
@@ -11643,7 +11643,7 @@ var mainGC = function() {
                 'settings_highlight_usercoords_it',
                 'settings_map_hide_found',
                 'settings_map_hide_hidden',
-                'settings_map_DNF_removeSmileys',
+                'settings_map_hide_dnfs',
                 'settings_map_hide_2',
                 'settings_map_hide_9',
                 'settings_map_hide_5',

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -401,6 +401,7 @@ var variablesInit = function(c) {
     c.settings_highlight_usercoords_it = getValue('settings_highlight_usercoords_it', true);
     c.settings_map_hide_found = getValue('settings_map_hide_found', true);
     c.settings_map_hide_hidden = getValue('settings_map_hide_hidden', true);
+    c.settings_map_DNF_hidden = getValue('settings_map_DNF_hidden', true);
     c.settings_map_hide_2 = getValue('settings_map_hide_2', false);
     c.settings_map_hide_9 = getValue('settings_map_hide_9', false);
     c.settings_map_hide_5 = getValue('settings_map_hide_5', false);
@@ -7271,6 +7272,12 @@ var mainGC = function() {
                 if (button) button.click();
             }
             if (settings_map_hide_hidden) isMapLoad(hideHiddenCaches);
+            function hideDNFCaches() {
+                if (document.location.href.match(/&asq=/)) return;
+                var button = unsafeWindow.document.getElementById("m_myCaches").childNodes[5];
+                if (button) button.click();
+            }
+            if (settings_map_DNF_hidden) isMapLoad(hideDNFCaches);
             function getAllCachetypeButtons(){
                 return ['Legend2', 'Legend9', 'Legend3', 'Legend6', 'Legend13', 'Legend453', 'Legend7005', 'Legend1304', 'Legend137', 'Legend4', 'Legend11', 'Legend8', 'Legend5', 'Legend1858'];
             }
@@ -10472,6 +10479,9 @@ var mainGC = function() {
             html += checkboxy('settings_hide_map_header', 'Hide header by default') + "<br>";
             html += checkboxy('settings_map_hide_found', 'Hide found caches by default') + prem + "<br>";
             html += checkboxy('settings_map_hide_hidden', 'Hide own caches by default') + prem + "<br>";
+            html += newParameterOn1;
+            html += checkboxy('settings_map_DNF_hidden', 'Hide DNFs by default') + prem + "<br>";
+            html += newParameterVersionSetzen('0.10') + newParameterOff;
             html += "&nbsp;" + "Hide cache types by default: " + prem + "<br>";
 
             var imgStyle = "style='padding-top: 4px; vertical-align: bottom;'";
@@ -11633,6 +11643,7 @@ var mainGC = function() {
                 'settings_highlight_usercoords_it',
                 'settings_map_hide_found',
                 'settings_map_hide_hidden',
+                'settings_map_DNF_hidden',
                 'settings_map_hide_2',
                 'settings_map_hide_9',
                 'settings_map_hide_5',

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -401,7 +401,7 @@ var variablesInit = function(c) {
     c.settings_highlight_usercoords_it = getValue('settings_highlight_usercoords_it', true);
     c.settings_map_hide_found = getValue('settings_map_hide_found', true);
     c.settings_map_hide_hidden = getValue('settings_map_hide_hidden', true);
-    c.settings_map_DNF_hidden = getValue('settings_map_DNF_hidden', true);
+    c.settings_map_DNF_removeSmileys = getValue('settings_map_DNF_removeSmileys', true);
     c.settings_map_hide_2 = getValue('settings_map_hide_2', false);
     c.settings_map_hide_9 = getValue('settings_map_hide_9', false);
     c.settings_map_hide_5 = getValue('settings_map_hide_5', false);
@@ -7272,12 +7272,12 @@ var mainGC = function() {
                 if (button) button.click();
             }
             if (settings_map_hide_hidden) isMapLoad(hideHiddenCaches);
-            function hideDNFCaches() {
+            function removeDNFSmileys() {
                 if (document.location.href.match(/&asq=/)) return;
                 var button = unsafeWindow.document.getElementById("m_myCaches").childNodes[5];
                 if (button) button.click();
             }
-            if (settings_map_DNF_hidden) isMapLoad(hideDNFCaches);
+            if (settings_map_DNF_removeSmileys) isMapLoad(removeDNFSmileys);
             function getAllCachetypeButtons(){
                 return ['Legend2', 'Legend9', 'Legend3', 'Legend6', 'Legend13', 'Legend453', 'Legend7005', 'Legend1304', 'Legend137', 'Legend4', 'Legend11', 'Legend8', 'Legend5', 'Legend1858'];
             }
@@ -10480,7 +10480,7 @@ var mainGC = function() {
             html += checkboxy('settings_map_hide_found', 'Hide found caches by default') + prem + "<br>";
             html += checkboxy('settings_map_hide_hidden', 'Hide own caches by default') + prem + "<br>";
             html += newParameterOn1;
-            html += checkboxy('settings_map_DNF_hidden', 'Hide DNFs by default') + prem + "<br>";
+            html += checkboxy('settings_map_DNF_removeSmileys', 'Remove DNF smileys by default') + prem + "<br>";
             html += newParameterVersionSetzen('0.10') + newParameterOff;
             html += "&nbsp;" + "Hide cache types by default: " + prem + "<br>";
 
@@ -11643,7 +11643,7 @@ var mainGC = function() {
                 'settings_highlight_usercoords_it',
                 'settings_map_hide_found',
                 'settings_map_hide_hidden',
-                'settings_map_DNF_hidden',
+                'settings_map_DNF_removeSmileys',
                 'settings_map_hide_2',
                 'settings_map_hide_9',
                 'settings_map_hide_5',


### PR DESCRIPTION
#1115 

Ich habe die variable für den config nicht ans Ende gepackt, da ich finde, dass sie thematische zu den anderen passt und es verwirrend wäre, wenn sie unten stehen würde.