### PR TITLE
Correct Mystery radius for Flopp

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -2395,12 +2395,12 @@ var mainGC = function() {
             } else if (waypoint.source == "original" ) {
                 radius = 0;
                 if (waypoint.typeid == 2 /* Traditional Geocache */ ) radius = 161; //  161m radius
-                else if (waypoint.typeid == 8 /* Mystery cache */) radius = 3000; // Mystery cache 3000m radius
+                else if (waypoint.typeid == 8 /* Mystery cache */) radius = 3200; // Mystery cache 3200m radius
                 name = normalizeName(waypoint.gccode+'_ORIGINAL');
             } else if (waypoint.source == "listing" ) {
                 radius = 0;
                 if (waypoint.typeid == 2 /* Traditional Geocache */ ) radius = 161; //  161m radius
-                else if (waypoint.typeid == 8 /* Mystery cache */) radius = 3000; // Mystery cache 3000m radius
+                else if (waypoint.typeid == 8 /* Mystery cache */) radius = 3200; // Mystery cache 3200m radius
                 name = normalizeName(waypoint.gccode);
             } else if (waypoint.source == "GClh Config" ) {
                 radius = 0;


### PR DESCRIPTION
Maximum distance between Mystery listing and final coordinates is 3200m, not 3000m as currently stated in the script. The info is used to draw the circle on Flopps map.

"Final coordinates must be less than 2 miles (3.2 km) from the posted coordinates." https://www.geocaching.com/play/guidelines