### PR TITLE
Problems-with-some-special-characters-at-ownerlink

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -8038,10 +8038,10 @@ var mainGC = function() {
 
             // Set link to owner.
             function setLinkToOwner() {
-                if ($('.geocache-owner')[0]) {
+                if ($('.geocache-owner')[0] && $('.cache-metadata-code')[0]) {
+                    if ($('#' + $('.cache-metadata-code')[0].innerHTML + '_owner')[0]) return;
                     var owner = ($('.geocache-owner-name span a')[0] ? $('.geocache-owner-name span a').html() : $('.geocache-owner-name span').html());
-                    if ($('#' + owner) [0]) return;
-                    var html = '<a id="' + owner + '" href="https://www.geocaching.com/profile/?u=' + urlencode(owner) + '" target="_blank">' + owner + '</a>';
+                    var html = '<a id="' + $('.cache-metadata-code')[0].innerHTML + '_owner' + '" href="https://www.geocaching.com/profile/?u=' + urlencode(owner) + '" target="_blank">' + owner + '</a>';
                     $('.geocache-owner-name span').html(html);
                 }
             }


### PR DESCRIPTION
Das Script stürzte bei Ownernamen mit Sonderzeichen am Anfang des Namens ab. Es liegt an der ID-Abfrage in `setLinkToOwner()`

Beispiel: 
https://www.geocaching.com/play/map?gc=GC7ZZYH

#1317