### PR TITLE
Issue #1622 New Helpful Buttons not working after loading more logs

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -7026,7 +7026,7 @@ var mainGC = function() {
                     global_logs = logs;
                     global_num = num;
                     window.addEventListener("scroll", function (event) {
-                        gclh_dynamic_load();
+                        gclh_dynamic_load(logs, num);
                         event.stopPropagation();
                     }, true);
                 }


### PR DESCRIPTION
Simple and easy fix.
Die Parameter wurden nicht an die Subfunktion weitergegeben und darum konnte nicht darauf zugegriffen werden.