### PR TITLE
[Cache Listing] Switch Geonames service to more secure https

### DIFF
--- a/data/gclh_defi.js
+++ b/data/gclh_defi.js
@@ -110,7 +110,7 @@ function elevationServicesDataInit(c) {
         { "function": undefined, 'name': 'no' },
         { "url" : "https://maps.googleapis.com/maps/api/elevation/json?sensor=false&locations={locations}", "function": undefined, 'name': 'Google Elevation' },
         { "url" : "https://api.open-elevation.com/api/v1/lookup?locations={locations}", "function": undefined, 'name': 'Open-Elevation' },
-        { "url" : "http://api.geonames.org/astergdemJSON?{locations}", "function": undefined, 'name': 'Geonames-Elevation' }
+        { "url" : "https://secure.geonames.org/astergdemJSON?{locations}", "function": undefined, 'name': 'Geonames-Elevation' }
     ];
 }
 

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -22,7 +22,7 @@
 // @connect          maps.googleapis.com
 // @connect          raw.githubusercontent.com
 // @connect          api.open-elevation.com
-// @connect          api.geonames.org
+// @connect          secure.geonames.org
 // @connect          coord.info
 // @description      Some little things to make life easy (on www.geocaching.com).
 // @copyright        2010-2016 Torsten Amshove, 2016-2021 2Abendsegler, 2017-2021 Ruko2010


### PR DESCRIPTION
Update Geonames service to more secure https protocol.

Recently I ran into the issue that the elevation in cache listings could not be retrieved anymore by Geonames service in Firefox.

Reason was the Firefox setting "Nur-HTTPS-Modus in allen Fenstern aktivieren" in "Datenschutz und Sicherheit".
This setting prevents proper fetching of data from [http://api.geonames.org](http://api.geonames.org) since the certificate isn't trustworthy.

A switch to [https://secure.geonames.org](https://secure.geonames.org) solves the issue.