### PR TITLE
Geonames fallback (2)

### DIFF
--- a/data/init.js
+++ b/data/init.js
@@ -132,9 +132,6 @@ function elevationServicesDataInit(c) {
         { "function": undefined, 'name': 'no' },
         { "url" : "https://maps.googleapis.com/maps/api/elevation/json?sensor=false&locations={locations}", "function": undefined, 'name': 'Google Elevation' },
         { "url" : "https://api.open-elevation.com/api/v1/lookup?locations={locations}", "function": undefined, 'name': 'Open-Elevation' },
-        { "url" : "https://secure.geonames.org/astergdemJSON?{locations}", "function": undefined, 'name': 'Geonames-Elevation' }
-    ];
-    c.elevationServicesDataFallback = [
         { "url" : "http://api.geonames.org/astergdemJSON?{locations}", "function": undefined, 'name': 'Geonames-Elevation' }
     ];
 }

--- a/data/init.js
+++ b/data/init.js
@@ -134,6 +134,9 @@ function elevationServicesDataInit(c) {
         { "url" : "https://api.open-elevation.com/api/v1/lookup?locations={locations}", "function": undefined, 'name': 'Open-Elevation' },
         { "url" : "https://secure.geonames.org/astergdemJSON?{locations}", "function": undefined, 'name': 'Geonames-Elevation' }
     ];
+    c.elevationServicesDataFallback = [
+        { "url" : "http://api.geonames.org/astergdemJSON?{locations}", "function": undefined, 'name': 'Geonames-Elevation' }
+    ];
 }
 
 function country_idInit(c) {

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -31,6 +31,7 @@
 // @connect      raw.githubusercontent.com
 // @connect      api.open-elevation.com
 // @connect      secure.geonames.org
+// @connect      api.geonames.org
 // @connect      coord.info
 // @grant        GM_getValue
 // @grant        GM_setValue
@@ -3418,6 +3419,7 @@ var mainGC = function() {
             elevationServicesData[1]['function'] = addElevationToWaypoints_GoogleElevation;
             elevationServicesData[2]['function'] = addElevationToWaypoints_OpenElevation;
             elevationServicesData[3]['function'] = addElevationToWaypoints_GeonamesElevation;
+            elevationServicesDataFallback[0]['function'] = addElevationToWaypoints_GeonamesElevation;
             function addElevationToWaypoints_GoogleElevation(responseDetails) {
                 try {
                     context = responseDetails.context;
@@ -3481,9 +3483,9 @@ var mainGC = function() {
                     context = responseDetails.context;
                     if (responseDetails.responseText.match(/<html>/)) {
                         if (responseDetails.responseText.match(/Service Unavailable/)) {
-                            gclh_log("\naddElevationToWaypoints_GeonamesElevation():\n- Info: Service Unavailable");
+                            gclh_log("\naddElevationToWaypoints_GeonamesElevation():\n- Info: Service Unavailable\n- url: "+responseDetails.finalUrl);
                         } else {
-                            gclh_log("\naddElevationToWaypoints_GeonamesElevation():\n- Error:\n"+responseDetails.responseText);
+                            gclh_log("\naddElevationToWaypoints_GeonamesElevation():\n- Error:\n"+responseDetails.responseText+"\n- url: "+responseDetails.finalUrl);
                         }
                         getElevations(context.retries+1,context.locations);
                         return;
@@ -3560,9 +3562,15 @@ var mainGC = function() {
             var elevationServices = [];
             if (settings_primary_elevation_service > 0) {
                 elevationServices.push(elevationServicesData[settings_primary_elevation_service]);
+                if (elevationServicesData[settings_primary_elevation_service] && elevationServicesData[settings_primary_elevation_service]['name'] == "Geonames-Elevation") {
+                    elevationServices.push(elevationServicesDataFallback[0]);
+                }
             }
             if (settings_secondary_elevation_service > 0) {
                 elevationServices.push(elevationServicesData[settings_secondary_elevation_service]);
+                if (elevationServicesData[settings_secondary_elevation_service] && elevationServicesData[settings_secondary_elevation_service]['name'] == "Geonames-Elevation") {
+                    elevationServices.push(elevationServicesDataFallback[0]);
+                }
             }
             // This function can be re-entered.
             function getElevations(serviceIndex,locations) {

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -30,7 +30,6 @@
 // @connect      maps.googleapis.com
 // @connect      raw.githubusercontent.com
 // @connect      api.open-elevation.com
-// @connect      secure.geonames.org
 // @connect      api.geonames.org
 // @connect      coord.info
 // @grant        GM_getValue
@@ -3419,7 +3418,6 @@ var mainGC = function() {
             elevationServicesData[1]['function'] = addElevationToWaypoints_GoogleElevation;
             elevationServicesData[2]['function'] = addElevationToWaypoints_OpenElevation;
             elevationServicesData[3]['function'] = addElevationToWaypoints_GeonamesElevation;
-            elevationServicesDataFallback[0]['function'] = addElevationToWaypoints_GeonamesElevation;
             function addElevationToWaypoints_GoogleElevation(responseDetails) {
                 try {
                     context = responseDetails.context;
@@ -3562,15 +3560,9 @@ var mainGC = function() {
             var elevationServices = [];
             if (settings_primary_elevation_service > 0) {
                 elevationServices.push(elevationServicesData[settings_primary_elevation_service]);
-                if (elevationServicesData[settings_primary_elevation_service] && elevationServicesData[settings_primary_elevation_service]['name'] == "Geonames-Elevation") {
-                    elevationServices.push(elevationServicesDataFallback[0]);
-                }
             }
             if (settings_secondary_elevation_service > 0) {
                 elevationServices.push(elevationServicesData[settings_secondary_elevation_service]);
-                if (elevationServicesData[settings_secondary_elevation_service] && elevationServicesData[settings_secondary_elevation_service]['name'] == "Geonames-Elevation") {
-                    elevationServices.push(elevationServicesDataFallback[0]);
-                }
             }
             // This function can be re-entered.
             function getElevations(serviceIndex,locations) {


### PR DESCRIPTION
#1857

@capoaira 
Ich habe die Anpassungen etwas anders realisiert, weil
- mit dem Namen des Services, also hier 'Geonames-Elevation', einiges verbunden ist. Deshalb müssen wir auch für den Fallback diesen Namen verwenden.
- in der Service Auswahl im Config der Fallback nicht wählbar sein darf.
- der Fallback unmittelbar nach dem Original laufen sollte und nicht als letztes.

Getestet habe ich durch Manipulation von `function addElevationToWaypoints_GeonamesElevation`. Dort habe ich die Secure url als Service unavailable deklariert. Die Secure url lief also auf Fehler und anschließend lief der Fallback. Im Fehlerfall wird nun auch die url mit in die Console geschrieben damit wir die beiden Services unterscheiden können. 

Das sollte also passen. 😬