### PR TITLE
Open caches in new tab in BML

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -5225,7 +5225,7 @@ var mainGC = function() {
             }
             // Disable entry 'Open selected caches in new browser tabs' if no caches are selected.
             function disableOpenTabsLists(mouseover) {
-                if (!$('table.geocache-table tr .checked')[0]) {
+                if (!$('table.geocache-table tbody tr input:checked')[0]) {
                     $('#gclh_open_tabs').addClass('disabled');
                 }
             }
@@ -5233,8 +5233,8 @@ var mainGC = function() {
             function openTabsLists(click, entryDD) {
                 if (!$('#gclh_open_tabs')[0]) return;
                 var caches = [];
-                $('table.geocache-table tr').each(function() {
-                    if ($(this).find('.checked')[0] && $(this).find('.geocache-name a')[0] && $(this).find('.geocache-name a')[0].href) {
+                $('table.geocache-table tbody tr').each(function() {
+                    if ($(this).find('input:checked')[0] && $(this).find('.geocache-name a')[0] && $(this).find('.geocache-name a')[0].href) {
                         if (browser == 'chrome') window.open($(this).find('.geocache-name a')[0].href);
                         else caches.push($(this).find('.geocache-name a')[0].href);
                     }


### PR DESCRIPTION
Upload js
#1926

---
@capoaira
Bitte schau kurz drüber. Wenns passt kannst du gerne mergen.

Der Menüeintrag war nicht nur bei fremden, sondern auch bei eigenen Bookmarklisten nicht wählbar.
Nach einer entsprechenden Änderung funktionierte das Öffnen der Tabs nicht. Hier war auch noch eine Änderung notwendig.