### PR TITLE
+Set default log form styling

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -4275,6 +4275,9 @@ var mainGC = function() {
                         document.getElementById('LogText').value += value;
                         document.getElementById('gclh_log_tpls').value = -1;
                     }
+                    var selLogText = '#LogText';
+                    $(selLogText).css('overflow', 'hidden scroll');
+                    $(selLogText).css('min-height', '300px');
                     document.getElementById('LogText').focus();
                     document.getElementById('LogText').selectionEnd = initial_cursor_position;
                     // Auch im Log Preview zur Anzeige bringen.


### PR DESCRIPTION
Hier gleich noch eine kleine Änderung: Wenn die Signatur in das textarea eingefügt wird, kann man in dem Feld nicht scrollen. Erst wenn man ein Zeichen einfügt, ist das möglich. Man musst erst irgendwo hin klicken, ein Zeichen einfügen und erst dann kann man mit seinem Cursor an die gewünschte Stelle.

Habe hier mit KeyEvents, Slection-Ranges, Focus und Blur probiert. Leider kein Erfolg das Event von GS zu triggern. Daher dieser kleine Umweg. Sobald man dann ein Zeichen tippt, wird die Änderung von GS wieder überschreiben und alles ist so, wie es sich GS das vorstellt.