### PR TITLE
[Config] Green signs in config fields.

### DIFF
--- a/data/main.css
+++ b/data/main.css
@@ -829,6 +829,11 @@ table .markdown-output~tr.AlternatingRow td {
     text-decoration: underline;
     color: #3d76c5;
 }
+.gclh_content select:hover,
+.gclh_content select:active,
+.gclh_content select:focus {
+    background-image: none;
+}
 .gclh_content table {
     margin-bottom: 0px;
     font-size: 14px;


### PR DESCRIPTION
Verhindern, dass im Config grüne Zeichen in select Feldern auftauchen, wenn man mit der Maus übers Feld geht. Passiert beispielsweise wenn Config aus neuem Log Formular aufgerufen wird. Beispielfeld "Set default language".

![grafik](https://user-images.githubusercontent.com/22332216/190249637-fd483642-46e5-42df-8e44-ce990d6f5e14.png)
