### PR TITLE
Fix count drafts after uploading or deletig

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -6351,7 +6351,7 @@ var mainGC = function() {
                     function waitForDrafts(waitCount) {
                         if ($('.draft-list li').length > count) {
                             count = $('.draft-list li').length;
-                            scrollAndCheck()
+                            scrollAndCheck();
                         } else {waitCount++; if (waitCount <= 100) setTimeout(function(){waitForDrafts(waitCount);}, 100);}
                     }
                     if (count != $('.draft-indicator a').html()) waitForDrafts(0);
@@ -6439,7 +6439,7 @@ var mainGC = function() {
                     }
                     // Show Logtype as icon.
                     if (settings_drafts_log_icons && $(this).find('.meta dt')[0] && $(this).find('.draft-icon')[0]) {
-                        let type = $(this).find('.meta dt').html().trim();
+                        let type = $(this).find('.meta dt').last().html().trim();
                         let typeHtml = `<div class="gclh_icon">
                                             ${$(this).find('.draft-icon').html()}
                                             <svg class="status-icon" height="22" width="22"><use xlink:href="https://www.geocaching.com/account/app/ui-icons/sprites/log-types.svg#icon-${logTypes[type]}"></use></svg>
@@ -6452,12 +6452,19 @@ var mainGC = function() {
                 });
                 // Show Cache Statistic.
                 statsBtn();
+                // Update Draft Indicator on Upload and Delete.
+                if ($('.draft-indicator a').html() != $('#draftsHeadingContiner h1').html().match(/\((\d+)\)/)[1]) {
+                    let totalDrafts = $('#draftsHeadingContiner h1').html().match(/\((\d+)\)/)[1];
+                    $('.draft-indicator a').html(totalDrafts);
+                }
             }
             // Build mutation observer.
             function buildObserverDrafts() {
                 var observerDrafts = new MutationObserver(function(mutations) {
                     mutations.forEach(function(mutation) {
+                        observerDrafts.disconnect();
                         processDrafts();
+                        observerDrafts.observe($('ul.draft-list')[0], {childList: true});
                     });
                 });
                 observerDrafts.observe($('ul.draft-list')[0], {childList: true});


### PR DESCRIPTION
- fix count drafts after uploading or deletig #2215 
- fix Cachetype not show if Cache ist Archived/Disabled (Zeile 6442)

Der Fehler, weshalb das Laden nicht aufgehört hat, ist, dass noch die alte statt die neue Anzahl von Drafts genutzt wurde. Das zu beheben hat aber nicht ganz geholfen, weil der `MutationObserver` rumgezickt hat.

Beim Test ist mir aufgefallen, dass bei archivierten Cache der Cachetyp nicht angezeigt wird, das wird durch Zeile 6442 behoben