### PR TITLE
Rework readme, installation tips, FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 *Powerful, configurable tool to improve and expand the geocaching pages.*
 
 ## Supported Browsers
-<a href="//"><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
+<a href="//" style="cursor: auto;"><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
 <a href="//"><img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome"></a>&nbsp;
 <a href="//"><img src="/images/safari_logo_small.png" title="Safari" alt="Safari"></a>&nbsp;
 <a href="//"><img src="/images/opera_logo_small.png" title="Opera" alt="Opera"></a>&nbsp;

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you need any help with the installation, you can have a look at our [installa
 ## Help
 If you want to ask questions, report bugs or request new features, you can do so on the following platforms (German and English): 
 - [Geocaching Forum](https://forums.geocaching.com/GC/index.php?/topic/343005-gc-little-helper-ii/)
-- [Geoclub Geocaching Forum](https://geoclub.de/forum/viewforum.php?f=117)
+- [Geoclub Geocaching Forum](https://www.geoclub.de/forum/t/gc-little-helper-ii-ab-v0-11.81650/)
 - [Swiss Geocache Forum](https://www.swissgeocacheforum.ch/forum/topic/12872-gc-little-helper-ii/)
 - [Forum](https://github.com/2Abendsegler/GClh/discussions) on our development platform at Github
 - [Ticket System](https://github.com/2Abendsegler/GClh/issues) on our development platform at Github
@@ -58,7 +58,7 @@ Wer Hilfe bei der Installation benötigt, wird in den [Tipps zur Installation](h
 ## Hilfe
 Wer Fehler melden möchte, Fragen stellen möchte oder neue Features beantragen möchte, der kann das auf folgenden Plattformen tun (Deutsch und Englisch): 
 - [Geocaching Forum](https://forums.geocaching.com/GC/index.php?/topic/343005-gc-little-helper-ii/)
-- [Geoclub Geocaching Forum](https://geoclub.de/forum/viewforum.php?f=117)
+- [Geoclub Geocaching Forum](https://www.geoclub.de/forum/t/gc-little-helper-ii-ab-v0-11.81650/)
 - [Swiss Geocache Forum](https://www.swissgeocacheforum.ch/forum/topic/12872-gc-little-helper-ii/)
 - [Forum](https://github.com/2Abendsegler/GClh/discussions) auf unserer Entwicklungsplattform bei Github
 - [Ticket System](https://github.com/2Abendsegler/GClh/issues) auf unserer Entwicklungsplattform bei Github

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <a href="//"><img src="/images/vivaldi_logo_small.png" title="Vivaldi" alt="Vivaldi"></a>
 
 ## How to install
-If you need any help with the installation, you can have a look at our [Installationtipps](https://github.com/2Abendsegler/GClh/blob/master/docu/tips_installation.md#en).
+If you need any help with the installation, you can have a look at our [installation tips](https://github.com/2Abendsegler/GClh/blob/master/docu/tips_installation.md#en).
 
 ## Help
 If you want to ask questions, report bugs or request new features, you can do so on the following platforms (German and English): 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 *Powerful, configurable tool to improve and expand the geocaching pages.*
 
 ## Supported Browsers
-<a href="//" style="cursor: auto;"><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
+<span><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></span>&nbsp;
 <a href="//"><img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome"></a>&nbsp;
 <a href="//"><img src="/images/safari_logo_small.png" title="Safari" alt="Safari"></a>&nbsp;
 <a href="//"><img src="/images/opera_logo_small.png" title="Opera" alt="Opera"></a>&nbsp;

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 *Powerful, configurable tool to improve and expand the geocaching pages.*
 
 ## Supported Browsers
-<img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox">&nbsp;
-<img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome">&nbsp;
-<img src="/images/safari_logo_small.png" title="Safari" alt="Safari">&nbsp;
-<img src="/images/opera_logo_small.png" title="Opera" alt="Opera">&nbsp;
-<img src="/images/microsoft_edge_logo_small.png" title="Microsoft Edge" alt="Microsoft Edge">&nbsp;
-<img src="/images/vivaldi_logo_small.png" title="Vivaldi" alt="Vivaldi">
+<a href="#"><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
+<a href="#"><img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome"></a>&nbsp;
+<a href="#"><img src="/images/safari_logo_small.png" title="Safari" alt="Safari"></a>&nbsp;
+<a href="#"><img src="/images/opera_logo_small.png" title="Opera" alt="Opera"></a>&nbsp;
+<a href="#"><img src="/images/microsoft_edge_logo_small.png" title="Microsoft Edge" alt="Microsoft Edge"></a>&nbsp;
+<a href="#"><img src="/images/vivaldi_logo_small.png" title="Vivaldi" alt="Vivaldi"></a>
 
 ## How to install
 If you need any help with the installation, you can have a look at our [Installationtipps](https://github.com/2Abendsegler/GClh/blob/master/docu/tips_installation.md#en).
@@ -45,12 +45,12 @@ All Geocacher and others are encouraged to help with the development or the supp
 *Mächtiges, konfigurierbares Tool zur Verbesserung und Erweiterung der Geocaching Seiten.*
 
 ## Unterstützte Browsers
-<img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox">&nbsp;
-<img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome">&nbsp;
-<img src="/images/safari_logo_small.png" title="Safari" alt="Safari">&nbsp;
-<img src="/images/opera_logo_small.png" title="Opera" alt="Opera">&nbsp;
-<img src="/images/microsoft_edge_logo_small.png" title="Microsoft Edge" alt="Microsoft Edge">&nbsp;
-<img src="/images/vivaldi_logo_small.png" title="Vivaldi" alt="Vivaldi">
+<a href="#"><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
+<a href="#"><img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome"></a>&nbsp;
+<a href="#"><img src="/images/safari_logo_small.png" title="Safari" alt="Safari"></a>&nbsp;
+<a href="#"><img src="/images/opera_logo_small.png" title="Opera" alt="Opera">&nbsp;
+<a href="#"><img src="/images/microsoft_edge_logo_small.png" title="Microsoft Edge" alt="Microsoft Edge"></a>&nbsp;
+<a href="#"><img src="/images/vivaldi_logo_small.png" title="Vivaldi" alt="Vivaldi"></a>
 
 ## Installationshinweise
 Wer Hilfe bei der Installation benötigt, wird in den [Tipps zur Installation](https://github.com/2Abendsegler/GClh/blob/master/docu/tips_installation.md#de) fündig.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 *Powerful, configurable tool to improve and expand the geocaching pages.*
 
 ## Supported Browsers
-<a href="#"><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
+<a><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
 <a href="#"><img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome"></a>&nbsp;
 <a href="#"><img src="/images/safari_logo_small.png" title="Safari" alt="Safari"></a>&nbsp;
 <a href="#"><img src="/images/opera_logo_small.png" title="Opera" alt="Opera"></a>&nbsp;

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 ## Supported Browsers
 <a href="//"><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
-<a href="#"><img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome"></a>&nbsp;
-<a href="#"><img src="/images/safari_logo_small.png" title="Safari" alt="Safari"></a>&nbsp;
-<a href="#"><img src="/images/opera_logo_small.png" title="Opera" alt="Opera"></a>&nbsp;
-<a href="#"><img src="/images/microsoft_edge_logo_small.png" title="Microsoft Edge" alt="Microsoft Edge"></a>&nbsp;
-<a href="#"><img src="/images/vivaldi_logo_small.png" title="Vivaldi" alt="Vivaldi"></a>
+<a href="//"><img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome"></a>&nbsp;
+<a href="//"><img src="/images/safari_logo_small.png" title="Safari" alt="Safari"></a>&nbsp;
+<a href="//"><img src="/images/opera_logo_small.png" title="Opera" alt="Opera"></a>&nbsp;
+<a href="//"><img src="/images/microsoft_edge_logo_small.png" title="Microsoft Edge" alt="Microsoft Edge"></a>&nbsp;
+<a href="//"><img src="/images/vivaldi_logo_small.png" title="Vivaldi" alt="Vivaldi"></a>
 
 ## How to install
 If you need any help with the installation, you can have a look at our [Installationtipps](https://github.com/2Abendsegler/GClh/blob/master/docu/tips_installation.md#en).
@@ -45,12 +45,12 @@ All Geocacher and others are encouraged to help with the development or the supp
 *Mächtiges, konfigurierbares Tool zur Verbesserung und Erweiterung der Geocaching Seiten.*
 
 ## Unterstützte Browsers
-<a href="#"><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
-<a href="#"><img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome"></a>&nbsp;
-<a href="#"><img src="/images/safari_logo_small.png" title="Safari" alt="Safari"></a>&nbsp;
-<a href="#"><img src="/images/opera_logo_small.png" title="Opera" alt="Opera">&nbsp;
-<a href="#"><img src="/images/microsoft_edge_logo_small.png" title="Microsoft Edge" alt="Microsoft Edge"></a>&nbsp;
-<a href="#"><img src="/images/vivaldi_logo_small.png" title="Vivaldi" alt="Vivaldi"></a>
+<a href="//"><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
+<a href="//"><img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome"></a>&nbsp;
+<a href="//"><img src="/images/safari_logo_small.png" title="Safari" alt="Safari"></a>&nbsp;
+<a href="//"><img src="/images/opera_logo_small.png" title="Opera" alt="Opera">&nbsp;
+<a href="//"><img src="/images/microsoft_edge_logo_small.png" title="Microsoft Edge" alt="Microsoft Edge"></a>&nbsp;
+<a href="//"><img src="/images/vivaldi_logo_small.png" title="Vivaldi" alt="Vivaldi"></a>
 
 ## Installationshinweise
 Wer Hilfe bei der Installation benötigt, wird in den [Tipps zur Installation](https://github.com/2Abendsegler/GClh/blob/master/docu/tips_installation.md#de) fündig.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 *Powerful, configurable tool to improve and expand the geocaching pages.*
 
 ## Supported Browsers
-<a><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
+<a href="//"><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
 <a href="#"><img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome"></a>&nbsp;
 <a href="#"><img src="/images/safari_logo_small.png" title="Safari" alt="Safari"></a>&nbsp;
 <a href="#"><img src="/images/opera_logo_small.png" title="Opera" alt="Opera"></a>&nbsp;

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 *Powerful, configurable tool to improve and expand the geocaching pages.*
 
 ## Supported Browsers
-<span><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></span>&nbsp;
+<a href="//"><img src="/images/mozilla_firefox_logo_small.png" title="Mozilla Firefox" alt="Mozilla Firefox"></a>&nbsp;
 <a href="//"><img src="/images/google_chrome_logo_small.png" title="Google Chrome" alt="Google Chrome"></a>&nbsp;
 <a href="//"><img src="/images/safari_logo_small.png" title="Safari" alt="Safari"></a>&nbsp;
 <a href="//"><img src="/images/opera_logo_small.png" title="Opera" alt="Opera"></a>&nbsp;

--- a/docu/faq.md
+++ b/docu/faq.md
@@ -158,7 +158,7 @@ We are happy about improvement suggestions, bugfixes or new features. This is re
 ## 8. Where can I get help with the GClh?
 If you need help with the GClh, or if you have questions about the GClh, you can create a note in the following forums ... :<br>
 - [Geocaching Forum](https://forums.geocaching.com/GC/index.php?/topic/343005-gc-little-helper-ii/)
-- [Geoclub Geocaching Forum](https://geoclub.de/forum/viewforum.php?f=117)
+- [Geoclub Geocaching Forum](https://www.geoclub.de/forum/t/gc-little-helper-ii-ab-v0-11.81650/)
 - [Swiss Geocache Forum](https://www.swissgeocacheforum.ch/forum/topic/12872-gc-little-helper-ii/)
 - [Discussions page](https://github.com/2Abendsegler/GClh/discussions) on our development platform at Github
 - [Ticket System](https://github.com/2Abendsegler/GClh/issues) on our development platform at Github
@@ -316,7 +316,7 @@ Wir freuen uns über Verbesserungsvorschläge, Bugfixes oder neue Features. Dies
 ## 8. Wo bekomme ich Hilfe zum GClh?
 Wenn du Hilfe zum GClh benötigst, oder wenn du Fragen zum GClh hast, dann kannst du dich in folgenden Foren ... melden:<br>
 - [Geocaching Forum](https://forums.geocaching.com/GC/index.php?/topic/343005-gc-little-helper-ii/)
-- [Geoclub Geocaching Forum](https://geoclub.de/forum/viewforum.php?f=117)
+- [Geoclub Geocaching Forum](https://www.geoclub.de/forum/t/gc-little-helper-ii-ab-v0-11.81650/)
 - [Swiss Geocache Forum](https://www.swissgeocacheforum.ch/forum/topic/12872-gc-little-helper-ii/)
 - [Diskussions Seite](https://github.com/2Abendsegler/GClh/discussions) auf unserer Entwicklungsplattform bei Github
 - [Ticket System](https://github.com/2Abendsegler/GClh/issues) auf unserer Entwicklungsplattform bei Github


### PR DESCRIPTION
- Supported Browser nicht mehr zum Bild verlinken weil das ziemlich häufig angewählt wird.
- Installation tips umbenennen.
- Change Geoclub link.