### PR TITLE
[Search Map] Corrected coordinates bug fix

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -9461,7 +9461,15 @@ var mainGC = function() {
             }
             // Process cache data.
             const processCaches = (state) => {
+                // Ensure that last selected cache marker is reset to original coords.
+                if (!isActive && state[0].postedCoordinatesSave) {
+                    state[0].postedCoordinates = state[0].postedCoordinatesSave;
+                    delete state[0].postedCoordinatesSave;
+                    return;
+                }
+                // Nothing to be done.
                 if (!isActive && !resetToPostedCoords) return;
+
                 // Move caches to corrected position or reset to original coords.
                 if (state[0].results && state[0].results[0]) {
                     let caches = state[0].results;
@@ -9491,7 +9499,8 @@ var mainGC = function() {
                     return;
                 }
                 // Keep selected cache marker at corrected position (otherwise it jumps to original coords).
-                if (state[0].userCorrectedCoordinates) {
+                if (state[0].userCorrectedCoordinates && !state[0].postedCoordinatesSave) {
+                    state[0].postedCoordinatesSave = state[0].postedCoordinates;
                     state[0].postedCoordinates = state[0].userCorrectedCoordinates;
                 }
             }


### PR DESCRIPTION
When switching back from corrected to original coordinates, the last selected cache marker jumps to corrected position when it gets selected as first cache. The marker should remain at original position.

Steps to reproduce:

1. Enable show at corrected coordinates
2. Select a cache and notice that the cache marker remains at corrected position
3. Switch to show at original coordinates
4. Select the very same cache and notice that the cache marker jumps to corrected position where it shouldn't