### PR TITLE
[Sync] Dropbox authentication keeps getting lost

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -285,7 +285,7 @@ var constInit = function(c) {
             c.bookmarks[i]['title'] = getValue("settings_bookmarks_title[" + i + "]");
         }
     }
-    c.gclhConfigKeysIgnoreForBackup = {"declared_version": true, "update_next_check": true};
+    c.gclhConfigKeysIgnoreForBackup = {"declared_version": true, "update_next_check": true, "settings_DB_auth_token": true};
     tlc('START iconsInit');
     iconsInit(c);
     tlc('START layersInit');


### PR DESCRIPTION
Do not save DB auth token in DB.