### PR TITLE
Log date not changeable for passed events in old log form

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -4472,6 +4472,17 @@ var mainGC = function() {
                         if (childs[i].value == select_val) select.selectedIndex = i;
                     }
                 }
+                // Bei Events wird nach dem Event Datum von GS automatisch der Logtype "Attended" gesetzt, sofern ein "Attended" noch nicht vorhanden ist.
+                // Das Log Datum steht dann auf dem aktuellen Datum und nicht auf dem Event Datum, was richtig wäre. Das Log Datum ist nicht eingabebereit.
+                // Unsere Default Einstellung settings_default_logtype_event zieht für diesen Fall nie. Der Fehler tritt auch ohne den GClh auf. Es handelt
+                // sich hier also um einen Bug auf der Webseite, der aber wohl kaum noch berichtigt wird.
+                if (select.value == "10") {
+                    var logdate = $("#uxDateVisited");
+                    var logdate_format = logdate.attr("userdateformat");
+                    var logdate_date = new Date($("#ctl00_ContentBody_LogBookPanel1_EventDate").val());
+                    var logdate_text = $.datepicker.formatDate(logdate_format, logdate_date);
+                    logdate.attr("value", logdate_text);
+                }
             }
             // Signature.
             var logtext = document.getElementById('ctl00_ContentBody_LogBookPanel1_uxLogInfo').value;


### PR DESCRIPTION
#2418

Bei Events wird nach dem Event Datum von GS automatisch der Logtype "Attended" gesetzt, sofern ein "Attended" noch nicht vorhanden ist. Das Log Datum steht dann auf dem aktuellen Datum und nicht auf dem Event Datum, was richtig wäre. Das Log Datum ist nicht eingabebereit. Unsere Default Einstellung `settings_default_logtype_event` zieht für diesen Fall nie. Der Fehler tritt auch ohne den GClh auf. Es handelt sich hier also um einen Bug auf der Webseite, der aber wohl kaum noch berichtigt wird.

To Reproduce:
1. Parameter [Use old-fashioned log form to log non drafts related logs](https://www.geocaching.com/my/#GClhShowConfig#a#settings_logs_old_fashioned) aktivieren
2. [Event](https://coord.info/GCADYGQ) aufrufen
3. Klick auf "Log your visit"  

---
Vor der Anpassung:

Das Event https://coord.info/GCADYGQ fand am 07.10.2023 statt. Im alten Logformular wird automatisch "Attended" gesetzt. Im Logdatum steht das aktuelle Tagesdatum. Das Logdatum ist nicht eingabebereit.
![Unbenannt 1](https://github.com/2Abendsegler/GClh/assets/22332216/85d8f133-3d74-4279-a076-b7ad349a35f4)

---
Nach der Anpassung nach den Vorschlägen von dennistreysa:

Nun wird als Logdatum das Eventdatum gesetzt.
![Unbenannt 2](https://github.com/2Abendsegler/GClh/assets/22332216/25d447f6-00db-4768-a7d7-215779930d88)

---
@capoaira 
Kannst du die Anpassung bitte testen. Danke.



