### PR TITLE
[Log View] "Copy Logtext to clipboard" icon is no longer supported for trackable logs.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -5419,7 +5419,7 @@ var mainGC = function() {
                 if (settings_hide_socialshare) css = 'ul.social-media-buttons {display: none !important;}';
             } catch(e) {gclh_error("Hide socialshare4 in improve log view",e);}
 
-            // Build copy to clipboard icon for logtext.
+            // Build copy to clipboard icon for logtext in cache logs.
             function buildCopyToClipboardForLogtext(waitCount) {
                 if ($('li.meta-data-item:last span.meta-data-label')[0] && !$('#gclh_copyLogtextToClipboard')[0]) {
                     $('li.meta-data-item:last span.meta-data-label').after('<span id="gclh_copyLogtextToClipboard"><span></span></span>');
@@ -5428,7 +5428,11 @@ var mainGC = function() {
                 waitCount++; if (waitCount <= 100) setTimeout(function(){buildCopyToClipboardForLogtext(waitCount);}, 100);
             }
             try {
-                if (typeof pageData !== 'undefined' && typeof pageData.logText !== 'undefined' && pageData.logText != '') {
+                // The icon is not always available for TB Logs.
+                // Background: After adding a TB log and after changing a TB log, you will automatically be taken to the View Log page. The View Log page
+                // is not accessed, only the page content is exchanged. Therefore the logtext is not available on the View Log page. See also pull request
+                // 2537 for further information.
+                if (!isTB && typeof pageData !== 'undefined' && typeof pageData.logText !== 'undefined' && pageData.logText != '') {
                     buildCopyToClipboardForLogtext(0);
                     css += 'li.meta-data-item:last-child {display: block;}';
                     css += 'li.meta-data-item:last-child > div {display: inline-block; margin-right: 8px;}';


### PR DESCRIPTION
The "Copy Logtext to clipboard" icon is no longer supported for trackable logs.

The icon is not always available for trackable logs.
Background: After adding a trackable log and after changing a trackable log, you will automatically be taken to the View Log page. The View Log page is not accessed, only the page content is exchanged. Therefore the logtext is not available on the View Log page.

Clarify the following issues:
- [Log View] "Copy Logtext to clipboard" icon not available after post a TB log. #2513 
- [Log Edit, Log View] "Copy Logtext to clipboard" icon does not contain the changed TB logtext after an update. #2523

Further information are in pull request #2522

---
close #2513
close #2523