### PR TITLE
[Search] Submenu is no longer aligned correctly.

### DIFF
--- a/data/main.css
+++ b/data/main.css
@@ -90,6 +90,7 @@ gclh_nav ul {
     overflow: initial;
     white-space: initial;
     text-overflow: ellipsis;
+    height: 37px;
 }
 .menu>li.mobile {
     display: none;

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -1725,6 +1725,9 @@ var mainGC = function() {
                     css += "nav .wrapper {padding-right: " + new_padding_right + "px !important; width: unset;}";
                     // Vertikales Menü ausrichten.
                     if (settings_bookmarks_top_menu) {
+                        if (is_page("find_cache")) {
+                            css += ".#m li:not(.attention-link-parent) ul.#sm {margin-top: 17px;}";
+                        }
                         css += ".#m ul.#sm {margin-top: 0px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
                         // Menü, Searchfield ausrichten in Abhängigkeit von Schriftgröße. Menü nicht flex.
                         if (settings_menu_float_right) {


### PR DESCRIPTION
![Ausrichtung untermenü](https://github.com/2Abendsegler/GClh/assets/22332216/46d9884c-ff3f-4187-89d8-12bf9dafbc3c)

Only search page is affected. All other pages checked, also the other tech migration pages.