### PR TITLE
[Google Maps] GC Map Icons overlap unpleasant with Google Maps elements.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -820,7 +820,7 @@ var mainGMaps = function() {
                     css += '#gclh_map_links svg:hover {opacity: 0.85;}';
                     css += '.search_map_icon {height: 20px !important;}';
                     css += '.gb_nd {padding-left: 4px;}';
-                    css += '.UV9Ngc {padding-right: 33px !important;}';
+                    css += '.UV9Ngc {padding-right: 48px !important;}';
                     appendCssStyle(css);
                 } else {waitCount++; if (waitCount <= 50) setTimeout(function(){addGcButton(waitCount);}, 200);}
             }


### PR DESCRIPTION
![Screen01](https://github.com/2Abendsegler/GClh/assets/22332216/7801b188-c543-4691-b92a-b505c8ebe12d)
