### PR TITLE
fix(Search Map) Link in cache details for caches with cache type "Geocaching HQ Block Party" missing

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -19896,6 +19896,7 @@ var mainGC = function() {
             else if (cacheType.match(/Groundspeak HQ/i)) cacheSymbol = '#hq';
             else if (cacheType.match(/event/i)) cacheSymbol = '#event';
             else if (cacheType.match(/GPS Adventures Exhibit Cache/i)) cacheSymbol = '#gpsa';
+            else if (cacheType.match(/Block Party/i)) cacheSymbol = '#blockparty'
         }
         return cacheSymbol;
     }


### PR DESCRIPTION
The link to the cache was not built for Block Parties.