### PR TITLE
[GitHub, Badge] Version and count of installations is no longer working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <a href="//"><img src="https://img.shields.io/github/last-commit/2Abendsegler/gclh"></a>
 <a href="//"><img src="https://img.shields.io/github/issues/2Abendsegler/GClh"></a><a href="//"><img src="https://img.shields.io/github/issues-closed/2Abendsegler/GClh?label="></a>
-<a href="//"><img src="https://img.shields.io/badge/dynamic/xml?url=https://raw.githubusercontent.com/2Abendsegler/GClh/master/last_version.txt&label=version&color=informational&query=/" title="current version"></a>
-<a href="//"><img src="https://img.shields.io/badge/dynamic/xml?url=http://c.andyhoppe.com/1676270686?output=text&label=installations&color=success&query=/" title="installations and updates"></a>
 <a href="//"><img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/2Abendsegler/GClh/master/README.md&count_bg=%2349c91b&title_bg=%23555555&icon=&title=hits&edge_flat=false" title="hits day / total"></a> &nbsp; <a href="//"><img src="https://img.shields.io/github/stars/2Abendsegler/gclh?style=social"></a><br>
 <br>
 <a href="#user-content-en" title=""><img src="/images/flag_en.png"></a>

--- a/docu/changelog.md
+++ b/docu/changelog.md
@@ -1,5 +1,3 @@
-<a href="//"><img src="https://img.shields.io/badge/dynamic/xml?url=https://raw.githubusercontent.com/2Abendsegler/GClh/master/last_version.txt&label=version&color=informational&query=/" title="current version"></a>
-<a href="//"><img src="https://img.shields.io/badge/dynamic/xml?url=http://c.andyhoppe.com/1676270686?output=text&label=installations&color=success&query=/" title="installations and updates"></a>
 <a href="//"><img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/2Abendsegler/GClh/master/docu/changelog.md&count_bg=%2349c91b&title_bg=%23555555&icon=&title=hits&edge_flat=false" title="hits day / total"></a><br>
 <br>
 <a href="#v0162" title="GClh II version 0.16.2 (30.08.2024)">v0.16.2</a> &nbsp;

--- a/docu/changelog_before.md
+++ b/docu/changelog_before.md
@@ -1,5 +1,3 @@
-<a href="//"><img src="https://img.shields.io/badge/dynamic/xml?url=https://raw.githubusercontent.com/2Abendsegler/GClh/master/last_version.txt&label=version&color=informational&query=/" title="current version"></a>
-<a href="//"><img src="https://img.shields.io/badge/dynamic/xml?url=http://c.andyhoppe.com/1676270686?output=text&label=installations&color=success&query=/" title="installations and updates"></a>
 <a href="//"><img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/2Abendsegler/GClh/master/docu/changelog_before.md&count_bg=%2349c91b&title_bg=%23555555&icon=&title=hits&edge_flat=false" title="hits day / total"></a><br>
 <br>
 <a href="changelog.md" title="Go to later changelog">Later changelog</a> &nbsp;

--- a/docu/overview_screenshots.md
+++ b/docu/overview_screenshots.md
@@ -1,4 +1,3 @@
-<a href="//"><img src="https://img.shields.io/badge/dynamic/xml?url=http://c.andyhoppe.com/1676270686?output=text&label=installations&color=success&query=/" title="installations and updates"></a>
 <a href="//"><img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/2Abendsegler/GClh/master/docu/overview_screenshots.md&count_bg=%2349c91b&title_bg=%23555555&icon=&title=hits&edge_flat=false" title="hits day / total"></a>
  &nbsp; <a href="//"><img src="https://img.shields.io/github/stars/2Abendsegler/gclh?style=social"></a>
 <br>

--- a/docu/tips_installation.md
+++ b/docu/tips_installation.md
@@ -1,5 +1,3 @@
-<a href="//"><img src="https://img.shields.io/badge/dynamic/xml?url=https://raw.githubusercontent.com/2Abendsegler/GClh/master/last_version.txt&label=version&color=informational&query=/" title="current version"></a>
-<a href="//"><img src="https://img.shields.io/badge/dynamic/xml?url=http://c.andyhoppe.com/1676270686?output=text&label=installations&color=success&query=/" title="installations and updates"></a>
 <a href="//"><img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/2Abendsegler/GClh/master/docu/tips_installation.md&count_bg=%2349c91b&title_bg=%23555555&icon=&title=hits&edge_flat=false" title="hits day / total"></a><br>
 <br>
 <a href="#en" title=""><img src="../images/flag_en.png"></a> &nbsp;<a href="#de" title=""><img src="../images/flag_de.png"></a>


### PR DESCRIPTION
Some badge logic for `shields.io` has changed. Version and count of installations is no longer working.