### PR TITLE
[TB Listing] The serial name has no longer been displayed for a travel bug or geocoin.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13444,19 +13444,27 @@ var mainGC = function() {
         } catch(e) {gclh_error("Show Coin-Sums",e);}
     }
 
-// Show Coin Series in TB-Listing.
+// Show TB, Coin Series in TB-Listing.
     if (document.location.href.match(/\.com\/track\/details\.aspx/)) {
         try {
-            if ($('#ctl00_ContentBody_BugTypeImage')[0] && $('#ctl00_ContentBody_BugTypeImage')[0].alt && $('.BugDetailsList')[0]) {
+            if ($('.BugDetailsList')[0]) {
                 var dl = $('.BugDetailsList')[0];
                 var dt = document.createElement("dt");
                 var dd = document.createElement("dd");
                 dt.innerHTML = "Series:";
-                dd.innerHTML = $('#ctl00_ContentBody_BugTypeImage')[0].alt;
-                dl.appendChild(dt);
-                dl.appendChild(dd);
+                if ($('#ctl00_ContentBody_BugTypeImage')[0] && $('#ctl00_ContentBody_BugTypeImage')[0].alt) {
+                    dd.innerHTML = $('#ctl00_ContentBody_BugTypeImage')[0].alt;
+                    dd.title = '(Determined from trackable icon)';
+                } else if ($('#ctl00_ContentBody_lbHeading')[0] && $('#ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoCode')[0] && $('head title')[0]) {
+                    dd.innerHTML = $('head title')[0].innerHTML.replace('(' + $('#ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoCode')[0].innerHTML + ') ', '').replace(' - ' + $('#ctl00_ContentBody_lbHeading')[0].innerHTML, '').trim();
+                    dd.title = '(Determined from page title)';
+                }
+                if (!dd.innerHTML == '') {
+                    dl.appendChild(dt);
+                    dl.appendChild(dd);
+                }
             }
-        } catch(e) {gclh_error("Show Coin Series",e);}
+        } catch(e) {gclh_error("Show TB, Coin Series",e);}
     }
 
 // Copy TB Code in TB Listing to clipboard.


### PR DESCRIPTION
Eigentlich wollte ich die Entwicklung bereits abbrechen, weil der Serien Name für den fraglichen TB "TB9916F" wieder angezeigt wird. Bei genauerem Hinsehen werden aber bei einigen TBs bzw. Coins keine Serien Namen ausgegeben. Tatsächlich wird "alt" bei einigen TBs mal geliefert und mal nicht. Das lässt sich bei folgenden TBs beobachten und das obwohl der Serien Name im Seiten Title vorhanden ist: 
https://coord.info/TB2V8GE
https://coord.info/TB9N38M
https://coord.info/TBA0Y0Q
https://coord.info/TB6WX9Z

Falls "alt" vorhanden ist wird der Serien Name nun von dort genommen, ansonsten wird er aus dem Seiten Title extrahiert.  

---
close #2678