### PR TITLE
Dashboard] Favorites icon almost completely disappears behind the found icon.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -9896,9 +9896,9 @@ var mainGC = function() {
                 }
             }
             if (settings_show_cache_type_icons_in_dashboard) {
-                css += '.activity-label .icon:nth-child(1) {margin-right: 0px;}';
-                css += '.activity-label.has-favorite .icon-favorited {position: relative; left: -8px; margin-right: -4px;}';
-                css += '.activity-label.has-favorite a {margin-left: 0;}';
+                css += '.activity-label .icon:nth-child(1) {margin-right: 0px !important;}';
+                css += '.activity-label.has-favorite .icon-favorited {position: relative !important; left: -8px !important; margin-right: -4px !important;}';
+                css += '.activity-label.has-favorite a {margin-left: 0 !important;}';
             }
 
             // Build log texts in Markdown.


### PR DESCRIPTION
Favoriten Icon verschwindet fast gänzlich hinter dem Found Icon und sitzt auch auf der falschen Seite des Found Icons. Das ist allerdings nicht immer der Fall. Scheinbar nur beim ersten Aufruf des Dashboards. Es werden unsere CSS Styles durch Webseiten eigene überschrieben. Das hängt wohl mit dem Zeitpunkt zusammen, wann die CSS Styles gesetzt werden.

alt:
![Screen03](https://github.com/user-attachments/assets/d590cd34-9a82-4aef-a2a1-dfe5fa2804f1)

neu:
![Screen04](https://github.com/user-attachments/assets/5f9814d4-72b1-4cf4-ba13-3827fc30f5f5)
