### PR TITLE
[Search Map] Some fixes after tech update

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -10709,22 +10709,13 @@ var mainGC = function() {
                 // 1) bookmark lists (url has special type)
                 // 2) mapping results from new search page or any stored search map url
                 //    -> parameters 'asc=' and 'sort=' are always present
-                // 3) matrix searches (covered by 2))
+                // 3) matrix searches (covered by 2)
                 if (document.location.href.match(/\.com\/live\/play\/map\?bmCode=/) ||
                     window.location.search.match(/asc=|sort=/)) {
                     return false;
                 } else return true;
             }
             if (run_setDefaultFilters()) {
-                /*// Wipe initial search results.
-                unsafeWindow.__NEXT_DATA__.props.pageProps.searchResults = {'results': [], 'total': 0};
-                // Wipe initial empty search sidebar content.
-                waitForElementThenRun('div.sidebar-content', () => {
-                    document.querySelector('div.sidebar-content').replaceChildren();
-                    document.querySelector('p.results-label').textContent = '';
-                    console.log('wipe initial sidebar content');
-                }, 20000);*/
-
                 // Perform search with default filters:
                 // 1) wait until filters are available (e.g. found status filter)
                 // 2) wait until GS default filters are applied (otherwise ours will be overridden):
@@ -10758,12 +10749,9 @@ var mainGC = function() {
                         observer.disconnect();
                         observer = null;
                     }
-                    const config = {
-                        attributes: true,
-                        attributeFilter: ["value"]
-                    };
-                    const observer = new MutationObserver(cb);
                     const target = document.querySelector('[data-event-label="Filters - Distance From"]');
+                    const config = { attributes: true, attributeFilter: ["value"] };
+                    let observer = new MutationObserver(cb);
                     observer.observe(target, config);
                 }
                 waitForElementThenRun('[data-event-label="Expand/Collapse Filters - Found Status"]', func, 20000);
@@ -10794,7 +10782,7 @@ var mainGC = function() {
                 //  Multi:   ct=3            Webcam:     ct=11       Cito:   ct=13
                 //  Mystery: ct=8            Wherigo:    ct=1858     Mega:   ct=453,1304,3774,4738
                 //  Earth:   ct=137          Virtual:    ct=4        Giga:   ct=7005
-                let types_to_show = {2: "Traditional", 3: "Multi-Cache", 4: "Virtual", 5: "Letterbox", 6: "Regular Event", 8: "Mystery", 11: "Webcam", 13: "CITO Event", 137: "EarthCache", 453: "Mega Event", 1858: "Wherigo", 7005: "Giga Event"};
+                let types_to_show = { 2: "Traditional", 3: "Multi-Cache", 4: "Virtual", 5: "Letterbox", 6: "Regular Event", 8: "Mystery", 11: "Webcam", 13: "CITO Event", 137: "EarthCache", 453: "Mega Event", 1858: "Wherigo", 7005: "Giga Event" };
                 const n_types = Object.keys(types_to_show).length;
                 // Remove hidden cache types from types_to_show.
                 for (let key in types_to_show) {
@@ -10820,6 +10808,7 @@ var mainGC = function() {
                     unsafeWindow.MapSettings.Map = state[0].map;
                 }
             }
+
             // Refresh map.
             const redrawMap = () => {
                 if (unsafeWindow.MapSettings?.Map?._mapPane) {
@@ -10831,6 +10820,7 @@ var mainGC = function() {
                     gclh_log('unsafeWindow.MapSettings.Map._mapPane not available');
                 }
             }
+
             // Process cache data.
             const processCaches = (state) => {
                 // Nothing to be done.
@@ -10854,6 +10844,7 @@ var mainGC = function() {
                     }
                 }
             }
+
             // Button for corrected coordinates.
             const addCorrectedCoordsButton = () => {
                 waitForElementThenRun("button.map-control", () => {
@@ -10885,6 +10876,7 @@ var mainGC = function() {
                     });
                 });
             }
+
             // Add button to toggle display of found caches between original and corrected coordinates.
             if (settings_show_found_caches_at_corrected_coords_but) {
                 var isActive = getValue('showCorrectedCoords', false);
@@ -10914,6 +10906,7 @@ var mainGC = function() {
                     });
                 }
             }
+
             // Disable corrected coords button for GM (displaying corrected coords works, but enabling/disabling doesn't work reliably).
             if (settings_show_found_caches_at_corrected_coords_but && !settings_use_gclh_layercontrol_on_search_map) {
                 const anchor = 'use[href="#map-layers"]';

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -12207,22 +12207,6 @@ var mainGC = function() {
                             }
                         }
                     }
-                    if (is_page("searchmap")) {
-                        // In Search map the list items do have an additional div element as 1st child
-                        // (whereas list items in Browse map don't).
-                        // TODO: seems like this is not the case anymore after tech update -> remove code section?
-                        for (var i=0; i<labels.length; i++) {
-                            if (labels[i].children[0].children[1].innerHTML.match(defaultLayer)) {
-                                // Wenn der erste Layer der Default Layer ist, wird er hiermit erneut klickbar gemacht.
-                                if (labels[i].children[0].children[0].checked && labels.length > 1) {
-                                    if (i == 0) labels[i+1].children[0].children[0].click();
-                                    else labels[i-1].children[0].children[0].click();
-                                }
-                                labels[i].children[0].children[0].click();
-                                break;
-                            }
-                        }
-                    }
                 }
                 var hs = ".gclh_layers.gclh_used .leaflet-control-layers-overlays";
                 if ($(hs).find('label input')[0]) {

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -10824,6 +10824,10 @@ var mainGC = function() {
             // Get map instance.
             const getMapInstance = (state) => {
                 //console.log('getMapInstance');
+
+                // if div#map-container has class .leaflet-container -> Leaflet
+                // else GM
+
                 // Only set once.
                 if (unsafeWindow.MapSettings.Map !== null) return;
 
@@ -12164,12 +12168,12 @@ var mainGC = function() {
                                     }
                                 } catch(e) {};
                             }
-                            if (document.location.pathname.match(/^\/play\/map/)) {
+                            if (document.location.pathname.match(/^\/live\/play\/map/)) {
                                 setTimeout(() => {
                                     // Remove default GS map tiles.
                                     document.querySelector('.mapboxgl-canvas').remove();
                                     // Adapt layout of gclh map layer control to GS controls.
-                                    document.querySelector('.leaflet-control-layers-toggle').setAttribute('style', 'width: 39px; height: 39px;');
+                                    document.querySelector('.leaflet-control-layers-toggle').setAttribute('style', 'width: 40px; height: 40px;');
                                     document.querySelector('#gclh_layers').setAttribute('style', 'border: 1px solid rgb(0, 178, 101);');
                                     // Ensure that map selection area is on top of map control buttons.
                                     document.querySelector('.leaflet-top.leaflet-right').setAttribute('style', 'z-index:1020;');
@@ -12207,6 +12211,7 @@ var mainGC = function() {
                     if (is_page("searchmap")) {
                         // In Search map the list items do have an additional div element as 1st child
                         // (whereas list items in Browse map don't).
+                        // TODO: seems like this is not the case anymore after tech update -> remove code section?
                         for (var i=0; i<labels.length; i++) {
                             if (labels[i].children[0].children[1].innerHTML.match(defaultLayer)) {
                                 // Wenn der erste Layer der Default Layer ist, wird er hiermit erneut klickbar gemacht.
@@ -12257,16 +12262,12 @@ var mainGC = function() {
             }
             addLayerControl();
             if (is_page('map')) loopAtLayerControls(0);
-            if (is_page('searchmap')) {
+            if (is_page('searchmap_new')) {
                 setDefaultsInLayer();
                 // Remove default GS layer control.
-                (function removeGSLayerControl(waitCount = 0) {
-                    if ($('.layer-control')[0]) {
-                        $('.layer-control').parent().remove();
-                        return;
-                    }
-                    if (++waitCount <= 200) setTimeout(function() { removeGSLayerControl(waitCount); }, 50);
-                })();
+                waitForElementThenRun('div.md\\:block', () => {
+                    $('div.md\\:block, div.md\\:hidden').remove();
+                });
             }
 
             var css = '';

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -10709,11 +10709,6 @@ var mainGC = function() {
                     console.log('wipe initial sidebar content');
                 }, 20000);*/
 
-                /*// Working hide sidebar.
-                waitForElementThenRun('button[data-testid="sidebar-toggle"]', () => {
-                    document.querySelector('button[data-testid="sidebar-toggle"]').click();
-                }, 20000);*/
-
                 // Perform search with default filters:
                 // 1) wait until filters are available (e.g. found status filter)
                 // 2) wait until GS default filters are applied (otherwise ours will be overridden):
@@ -11613,25 +11608,11 @@ var mainGC = function() {
             }
 
             // Hide sidebar.
-            let runHideSidebar = true;
-            function hideSidebar() {
-                // Run only once.
-                if (!settings_map_hide_sidebar || !runHideSidebar) return;
-                runHideSidebar = false;
-                // Close the sidebar.
-                function clickToClose(wc) {
-                    // The sidebar is still closed from the start, so wait.
-                    if (!$('.sidebar-toggle')[0] || $('body').hasClass('sidebar-is-closed')) {
-                        wc++;
-                        if (wc <= 25) setTimeout(function() { clickToClose(wc); }, 200);
-                    // The sidebar is now open.
-                    } else {
-                        $('div#sidebar-group>button.sidebar-toggle').click();
-                    }
-                }
-                clickToClose(0);
+            if (settings_map_hide_sidebar) {
+                waitForElementThenRun('button[data-testid="sidebar-toggle"]', () => {
+                    document.querySelector('button[data-testid="sidebar-toggle"]').click();
+                }, 20000);
             }
-            hideSidebar();
 
             // Improve add to list pop up.
             function improveAddtolistPopup() {
@@ -12224,7 +12205,7 @@ var mainGC = function() {
             }
             addLayerControl();
             if (is_page('map')) loopAtLayerControls(0);
-            if (is_page('searchmap_new')) {
+            if (is_page('searchmap')) {
                 setDefaultsInLayer();
                 // Remove default GS layer control.
                 waitForElementThenRun('div.md\\:block', () => {

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -11334,11 +11334,11 @@ var mainGC = function() {
 
             // Build map control buttons.
             function buildMapControlButtons() {
-                if (!$('.map-setting-controls ul')[0]) return;
+                if (!$('div.zoom-controls')[0]) return;
                 // Relocate browse button to other buttons.
-                if (settings_relocate_other_map_buttons && !$('#gclh_browse_map')[0] && $('#browse-map-cta')[0]) {
-                    $('.map-setting-controls ul li:first').before('<li role="menuitem"><button id="gclh_browse_map" class="map-control" title="Browse geocaches"><svg><use xlink:href="#globe"></use></svg></button></li>');
-                    $('#gclh_browse_map')[0].addEventListener("click", function() { $('#browse-map-cta')[0].click(); }, false);
+                if (settings_relocate_other_map_buttons && !$('#gclh_browse_map')[0] && $('[data-testid="gc-button-link"]')[0]) {
+                    $('div.zoom-controls').parent().prepend('<div class="hidden tablet:block"><button id="gclh_browse_map" class="map-control"><svg><title>Browse geocaches</title><use href="#globe"></use></svg></button></div>');
+                    $('#gclh_browse_map')[0].addEventListener("click", function() { document.querySelector('[data-testid="gc-button-link"]').click(); }, false);
                 }
                 // Add links to Google, OSM, Flopp's, GeoHack and Komoot Map.
                 if (!$('#gclh_geoservices_control')[0] && (settings_add_link_google_maps_on_gc_map || settings_add_link_osm_on_gc_map || settings_add_link_flopps_on_gc_map || settings_add_link_geohack_on_gc_map || settings_add_link_komoot_on_gc_map)) {
@@ -11974,8 +11974,7 @@ var mainGC = function() {
             css += '.map-control {margin-bottom: 10px !important;}';
             css += '.map-control svg {vertical-align: middle;}';
             css += '.map-controls section button, .map-controls .zoom-controls {margin-bottom: 10px; margin-top: 0px !important;}';
-            css += '#browse-map-cta {right: 10px;}';
-            if (settings_relocate_other_map_buttons) css += '#browse-map-cta {display: none !important;}';
+            if (settings_relocate_other_map_buttons) css += '[data-testid="gc-button-link"] {display: none !important;}';
             else css += '#gclh_layers {top: 52px;}';
             // Sidebar Enhancements.
             if (settings_show_enhanced_map_popup) {


### PR DESCRIPTION
Found some time and had a look into the search map issues after the tech update from GS.
Some of them are fixed with this PR:

1. map selection
2. default filters
3. relocate browse map button
4. hide sidebar
5. display found caches at corrected coordinates

Since some fixes depend on others it was easier to package all in one PR.
Nevertheless, the mentioned fixes are all separated by different commits.

If you find some time you could have a look at the changes.