### PR TITLE
[Cache Listing, Maps] Add county (Landkreis) to cache location

### DIFF
--- a/data/config_standard.txt
+++ b/data/config_standard.txt
@@ -386,5 +386,7 @@
   "settings_less_space_log_lines_log_form": true,
   "settings_listing_bigger_avatar_with_mouse": true,
   "settings_listing_ctoc_coords_waypoints": true,
-  "settings_default_logtype_control": true
+  "settings_default_logtype_control": true,
+  "settings_listing_add_county_to_place": false,
+  "settings_maps_add_county_to_place": false
 }


### PR DESCRIPTION
close #2419

- Beispiele: GC8NA1H, GCA4YT5, GC4T7NH, GC7YRJN, GC9C0TF, GC1RZ81, GCAJHWN (Unschön: Stadtgebiet Bremen)
- Das Problem mit "Stadtgebiet ..." scheint es nur in Bremen zu geben und es ist nur eingeschränkt vorhanden. Auch ansonsten habe ich keine Probleme mehr gefunden bzw. konnte sie ausbügeln.
- Geeignete Länder: de, at. Darauf ist die Erweiterung auch beschränkt.
- Nicht geeignete Länder weil Daten fehlen oder die Felder und teils auch die Namen selbst ganz anders sind: ch, cz, fr, li. Ich habe es bei meinen Tests dabei belassen.
- Sprachen: Country in Englisch so wie im Cache Listing, Bundesland und Landkreis ... in Deutsch.

---
https://www.geocaching.com/my/#GClhShowConfig#a#settings_maps_add_county_to_place
![Screen01](https://github.com/user-attachments/assets/a9c146e1-e1b5-40e0-aab7-d2b038e75298)
With this option, the county is added to the location of the cache if the cache location is in Germany or Austria. If you hover with your mouse over the field, the full address will be displayed.
The data comes from OpenStreetMap. They are not always completely accurate, which is why the parameter is deactivated by default. Other countries work with different data structures and the quality of the data does not always seem sufficient, which is why we have decided to only provide the named countries for this feature.

![Screen02](https://github.com/user-attachments/assets/d27d4d84-e0e2-41a9-a1aa-f542d78e2af5)

---
https://www.geocaching.com/my/#GClhShowConfig#a#settings_listing_add_county_to_place
![Screen03](https://github.com/user-attachments/assets/d611a6fe-42dc-4d1a-ad87-74fce136445a)

![Screen04](https://github.com/user-attachments/assets/a5dc6baf-dc54-4470-a62e-69d4cbfed41a)

