### PR TITLE
[Cache Listing] "One click ignoring" no longer works (workaround)

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -2642,6 +2642,9 @@ var mainGC = function() {
         try {
             // Set Ignore.
             changeIgnoreButton('Ignore');
+            // -> #2796: Deactivate feature "One click ignoring".
+            settings_use_one_click_ignoring = false;
+            // <- #2796
             // Prepare one click Ignore, Stop Ignoring.
             if (settings_use_one_click_ignoring) {
                 var link = '#ctl00_ContentBody_GeoNav_uxIgnoreBtn a';


### PR DESCRIPTION
Workaround for #2796:
Mit diesen Änderungen wird das Feature "One click ignoring" deaktiviert, damit es möglich ist, einen Cache weiterhin auf die Ignore Liste zu setzen bzw. von dort zu entfernen.