### PR TITLE
[View Log] Log display in full width.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -5633,6 +5633,8 @@ var mainGC = function() {
                 }
             }
             let css = '';
+            // Log display in full width.
+            css += '.log-view-body .log > div {max-width: none !important;}';
 
             // Build own edit button with real link. Is required for complete pageData on the edit log page.
             function buildOwnEditButton(waitCount) {


### PR DESCRIPTION
Before:
![1](https://github.com/user-attachments/assets/4028db46-1e79-4cbf-8faf-2ee8c28d2d93)

After:
![2](https://github.com/user-attachments/assets/31b88269-5441-4d13-bc82-4789d74711d2)

