### PR TITLE
[Cache Listing] "Order by ..." does not work if a fixed number of logs were previously displayed.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -9378,7 +9378,7 @@ var mainGC = function() {
                     new_sort_element.classList.add("isDisabled");;
                     new_sort_element.disabled = true;
                     new_sort_element.onchange = function() {
-                        if (!$('#search_logs_number_of_hits')[0].innerHTML == '') searchLogsReset(logs);
+                        searchLogsReset(logs);
                         var sorting_key = this.value;
                         // Deactivate buttons "Show log counter" and "Hide upvotes".
                         if (sorting_key != 'newest') {


### PR DESCRIPTION
Selecting logs via "Order by..." doesn't work if a fixed number of logs was previously displayed, for example, via the log type icons. The exact number of logs will then continue to be displayed. It would be correct to display only the number of logs for the initial startup.

This only worked if the fixed number of logs was generated by the "Search in logs" option.