### PR TITLE
[Search Map] Fix issues from tech migration

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -10561,17 +10561,24 @@ var mainGC = function() {
                         observer.observe(document.querySelector(anchor), {attributes: true, attributeName: "value"});
                     });
                 }
+            }
 
-                // Disable button for BML.
+            // Set click events to 'Search' and 'My Lists' that will handle enabling/disabling corrected coords button.
+            function addEnableDisableCorrectedCoordsHandler() {
                 waitForElementThenRun('button[data-testid="list-mode-toggle"]', () => {
-                    $('button[data-testid="list-mode-toggle"]').click(() => {
-                        document.querySelector('#gclh_corrected_coords').setAttribute('disabled', '');
-                    });
-                    $('button[data-testid="search-mode-toggle"]').click(() => {
-                        document.querySelector('#gclh_corrected_coords').removeAttribute('disabled');
-                        // Reinitialize map bounds.
-                        [latHighG, latLowG, lngHighG, lngLowG] = getMapBounds();
-                    });
+                    if (!$('ul[data-testid="mode-toggles"]').hasClass('gclh-mode-toggles')) {
+                        $('ul[data-testid="mode-toggles"]').addClass('gclh-mode-toggles');
+                        // Disable button for BML.
+                        $('button[data-testid="list-mode-toggle"]').click(() => {
+                            document.querySelector('#gclh_corrected_coords').setAttribute('disabled', '');
+                        });
+                        // Enable button for search lists.
+                        $('button[data-testid="search-mode-toggle"]').click(() => {
+                            document.querySelector('#gclh_corrected_coords').removeAttribute('disabled');
+                            // Reinitialize map bounds.
+                            [latHighG, latLowG, lngHighG, lngLowG] = getMapBounds();
+                        });
+                    }
                 });
             }
 
@@ -11468,6 +11475,7 @@ var mainGC = function() {
                 geocacheActionBar(); // "Save as PQ" and "Hide Header".
                 // Prepare keydown F2 filter screen.
                 prepareKeydownF2InFilterScreen();
+                if (settings_show_found_caches_at_corrected_coords_but) addEnableDisableCorrectedCoordsHandler();
             }
 
             // Observer callback for body and checking existence of sidebar.


### PR DESCRIPTION
This PR is a major improvement for displaying geocaches at corrected coordinates:
1.  no calls to searchThisArea necessary anymore (i.e. server load is reduced)
    -  on initial page load
    - when switching between corrected and original coordinates
2. enabling/disabling of corrected coordinates button now works more reliable (there were some corner cases)

Additionally, retrieving a handle to the Leaflet map is now less complex and requires fewer resources.

These changes were only possible due to #2822 and therefore are based upon that PR. 
All has been tested in Chrome, FF and Linux.
When reviewing #2822, it's maybe best to review directly this PR, since all changes and enhancements are combined.

All in all, these changes make the code less complex, more robust, easier to maintain, require fewer resources and reduce the server load.