### PR TITLE
[Cache Listing] "Additional Hints" are displayed next to the listing.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -1936,6 +1936,7 @@ var mainGC = function() {
                     if (!is_page("cache_listing")) css += ".UserSuppliedContent {width: " + (new_width - 200) + "px;}";
                     if (is_page("publicProfile")) css += ".container .profile-panel {width: " + (new_width - 160) + "px;}";
                     if (is_page("cache_listing")) {
+                        css += ".UserSuppliedContent {display: inline-block;}";
                         var widthSpan9 = new_width - 300 - 270 - 13 - 13 - 10 - 6.
                         if (widthSpan9 >= 500) {
                             css += ".span-9 {width: 500px !important;}";


### PR DESCRIPTION
If the width of the display is increased using the "Page width" parameter settings_new_width and the owner has specified a limit of 670 pixel in the listing as per the standard, then the heading "Additional Hints" will move up next to the listing.

Example [GCAPWMG](https://coord.info/GCAPWMG)

![Unbenannt1](https://github.com/user-attachments/assets/3d572cf1-1642-445c-8bd4-a7d13b01f397)
