### PR TITLE
[Search Map] More display options for search results

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -10547,12 +10547,92 @@ var mainGC = function() {
                 let gc = null;
                 for (let i = 0; i < caches.length; i++) {
                     gc = caches[i];
-                    // Change cache coords.
+                    // Hide finds.
+                    if (hideFinds && gc.userFound) {
+                        caches.splice(i--,1);
+                        continue;
+                    }
+                    // Hide own caches.
+                    if (hideOwned && gc.owner.code === layout.props.gcUser.referenceCode) {
+                        caches.splice(i--,1);
+                        continue;
+                    }
+                    // Hide past events.
+                    if (hidePastEvents && [6,13,453,1304,3653,3774,4738,7005].includes(gc.geocacheType)) {
+                        let today = new Date();
+                        // Interpret "past" as yesterday.
+                        today.setHours(0, 0, 0, 0);
+                        if (today > new Date(gc.placedDate)) {
+                            caches.splice(i--, 1);
+                            continue;
+                        }
+                    }
+                    // Hide Traditionals (Tradi + Project A.P.E. Cache + Geocaching HQ).
+                    if (hideTradis && [2,9,3773].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide Multis.
+                    if (hideMultis && [3].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide Events (Regular + Community Celebration Event).
+                    if (hideEvents && [6,3653].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide CITOs.
+                    if (hideCitos && [13].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide Megas (Mega + GPS Adventures Exhibit + Geocaching HQ Celebration + Geocaching HQ Block Party).
+                    if (hideMegas && [453,1304,3774,4738].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide Gigas.
+                    if (hideGigas && [7005].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide Earthcaches.
+                    if (hideEarthcaches && [137].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide Virtuals.
+                    if (hideVirtuals && [4].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide Webcams.
+                    if (hideWebcams && [11].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide Mysteries.
+                    if (hideMysteries && [8].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide Letterboxes.
+                    if (hideLetterboxes && [5].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide Wherigos.
+                    if (hideWherigos && [1858].includes(gc.geocacheType)) {
+                        caches.splice(i--, 1);
+                        continue;
+                    }
+                    // Hide DNF icons.
+                    if (hideDNFIcons && gc.userDidNotFind) delete gc.userDidNotFind;
+                    // Change original cache coords to corrected coords.
                     if (showAtCorrectedCoords && gc.userCorrectedCoordinates) {
                         gc.postedCoordinates = gc.userCorrectedCoordinates;
                     }
-                    // Hide DNF icon.
-                    if (hideDNFIcons && gc.userDidNotFind) delete gc.userDidNotFind;
                 }
             }
 
@@ -10561,85 +10641,535 @@ var mainGC = function() {
             function forceCachesRefresh() {
                 // The 'moveend' event triggers a 'getLayout' call, which in turn triggers a 'processCaches' call.
                 moveend_zoomend = true;
-                unsafeWindow.MapSettings.Map.fire('moveend');
+                unsafeWindow.MapSettings?.Map?.fire('moveend');
             }
 
-            // Button for additional geocache display options.
-            function cacheDisplayOptionsButton() {
+            // Button for additional display options of search results.
+            function addCacheDisplayOptionsButton() {
                 waitForElementThenRun("button.map-control", function() {
                     // Button.
-                    $('button.map-control').first().parent().parent().prepend('<button id="gclh_display_options_control" class="gclh_display_options_control map-control"></button>');
+                    const $parent = $('button.map-control').first().parent().parent();
+                    $parent.prepend(`
+                        <button id="gclh_display_options_control" class="gclh_display_options_control map-control"></button>
+                    `);
+                    const $control = $('#gclh_display_options_control');
+                    $control.append(`
+                        <svg>
+                            <title>Display Options for Search Results</title>
+                            <use href="#filters"></use>
+                        </svg>
+                        <div id="gclh_display_options_list" class="gclh_display_options_list"></div>
+                    `);
 
                     // Options list.
-                    $('#gclh_display_options_control').append('<svg><title>Geocache display options</title><use href="#filters"></use></svg>');
-                    $("#gclh_display_options_control").append('<div id="gclh_display_options_list" class="gclh_display_options_list"></div>');
-                    $("#gclh_display_options_list").append('<b>Geocache display options</b>');
-                    $("#gclh_display_options_list").append('<label for="gclh_showAtCorrectedCoords"><input type="checkbox" id="gclh_showAtCorrectedCoords" ' + (showAtCorrectedCoords ? 'checked' : '') + '>Show found caches at corrected coordinates</label>');
-                    $("#gclh_display_options_list").append('<label for="gclh_hideDNFIcons"><input type="checkbox" id="gclh_hideDNFIcons" ' + (hideDNFIcons ? 'checked' : '') + '>Hide DNF icons</label>');
+                    const $list = $("#gclh_display_options_list");
+                    // Header and tooltip.
+                    $list.append(`
+                        <b style="font-size: 16px;">Display Options for Search Results</b>
+                        <svg id="gclh_options_info" style="vertical-align: text-bottom; display: inline-block;">
+                            <title>Info</title>
+                            <use href="#tooltip"></use>
+                        </svg>
+                        <div class="gclh_options_info">
+                            These GClh options allow you to control the display of the current search results.<br><br>
+                            Caches can be hidden for the current session based on their status and type.<br><br>
+                            In addition, there are several other display options in the lower section that can be saved across multiple sessions.<br><br>
+                            Note: These options do not perform a new search themselves; they only affect the display of the current search results.
+                        </div>
+                    `);
+                    // Cache statuses and types.
+                    $list.append(`
+                        <div class="gclh_grid_container">
+                            <div style="grid-column: 1 / span 6; height: 1em;"></div>
+                            <!-- Cache statuses -->
+                            <div style="grid-column: 1 / span 6; margin-bottom: 5px;"><u>Show / Hide Caches by Status</u></div>
+                            <div>
+                                <svg id="gclh_hideLegendGray_svg" style="width: 0.75em !important; margin-right: 0.5em;">
+                                    <title>All statuses</title>
+                                    <use href="#cache_icon_small_disabled"></use>
+                                </svg>
+                                <input type="checkbox" id="gclh_hideLegendGray" ${hideLegendGray ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <span id="gclh_separatorGray" class="gclh_separator" style="width: 4px; height: 20px; background-color: lightgray; display: block;"></span>
+                            </div>
+                            <div>
+                                <svg id="gclh_hideFinds_svg">
+                                    <title>My Finds</title>
+                                    <use href="#smiley"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-gray" id="gclh_hideFinds" ${hideFinds ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <svg id="gclh_hideOwned_svg">
+                                    <title>My Hides</title>
+                                    <use href="#owned"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-gray" id="gclh_hideOwned" ${hideOwned ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <svg id="gclh_hidePastEvents_svg">
+                                    <title>Past Events</title>
+                                    <use href="#event_disabled"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-gray" id="gclh_hidePastEvents" ${hidePastEvents ? 'checked' : ''} style="display:none">
+                            </div>
+                            
+                            <!-- Cache types -->
+                            <div style="grid-column: 1 / span 6; height: 1em;"></div>
+                            <div style="grid-column: 1 / span 6; margin-bottom: 5px;"><u>Show / Hide Caches by Type</u></div>
+                            <!-- Green types -->
+                            <div>
+                                <svg id="gclh_hideLegendGreen_svg" style="width: 0.75em !important; margin-right: 0.5em;">
+                                    <title>All green types</title>
+                                    <use href="#cache_icon_small_traditional"></use>
+                                </svg>
+                                <input type="checkbox" id="gclh_hideLegendGreen" ${hideLegendGreen ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <span id="gclh_separatorGreen" class="gclh_separator" style="width: 4px; height: 20px; background-color: forestgreen; display: block;"></span>
+                            </div>
+                            <div style="grid-column: 3 / span 4;">
+                                <svg id="gclh_hideTradis_svg">
+                                    <title>Traditionals</title>
+                                    <use href="#traditional"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-green" id="gclh_hideTradis" ${hideTradis ? 'checked' : ''} style="display:none">
+                            </div>
+                            <!-- Orange types -->
+                            <div>
+                                <svg id="gclh_hideLegendOrange_svg" style="width: 0.75em !important; margin-right: 0.5em;">
+                                    <title>All orange types</title>
+                                    <use href="#cache_icon_small_multi"></use>
+                                </svg>
+                                <input type="checkbox" id="gclh_hideLegendOrange" ${hideLegendOrange ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <span id="gclh_separatorOrange" class="gclh_separator" style="width: 4px; height: 20px; background-color: darkorange; display: block;"></span>
+                            </div>
+                            <div style="grid-column: 3 / span 4;">
+                                <svg id="gclh_hideMultis_svg">
+                                    <title>Multi-Caches</title>
+                                    <use href="#multi"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-orange" id="gclh_hideMultis" ${hideMultis ? 'checked' : ''} style="display:none">
+                            </div>
+                            <!-- Red types -->
+                            <div>
+                                <svg id="gclh_hideLegendRed_svg" style="width: 0.75em !important; margin-right: 0.5em;">
+                                    <title>All red types</title>
+                                    <use href="#cache_icon_small_event"></use>
+                                </svg>
+                                <input type="checkbox" id="gclh_hideLegendRed" ${hideLegendRed ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <span id="gclh_separatorRed" class="gclh_separator" style="width: 4px; height: 20px; background-color: darkred; display: block;"></span>
+                            </div>
+                            <div>
+                                <svg id="gclh_hideEvents_svg">
+                                    <title>Events / Community Celebration Events</title>
+                                    <use href="#event"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-red" id="gclh_hideEvents" ${hideEvents ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <svg id="gclh_hideCitos_svg">
+                                    <title>Cache In Trash Out Events</title>
+                                    <use href="#cito"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-red" id="gclh_hideCitos" ${hideCitos ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <svg id="gclh_hideMegas_svg">
+                                    <title>Mega-Events</title>
+                                    <use href="#mega"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-red" id="gclh_hideMegas" ${hideMegas ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <svg id="gclh_hideGigas_svg">
+                                    <title>Giga-Events</title>
+                                    <use href="#giga"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-red" id="gclh_hideGigas" ${hideGigas ? 'checked' : ''} style="display:none">
+                            </div>
+                            <!-- Turquoise types -->
+                            <div>
+                                <svg id="gclh_hideLegendTurquoise_svg" style="width: 0.75em !important; margin-right: 0.5em;">
+                                    <title>All turquoise types</title>
+                                    <use href="#cache_icon_small_virtual"></use>
+                                </svg>
+                                <input type="checkbox" id="gclh_hideLegendTurquoise" ${hideLegendTurquoise ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <span id="gclh_separatorTurquoise" class="gclh_separator" style="width: 4px; height: 20px; background-color: #009bbb; display: block;"></span>
+                            </div>
+                            <div>
+                                <svg id="gclh_hideEarthcaches_svg">
+                                    <title>EarthCaches</title>
+                                    <use href="#earth"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-turquoise" id="gclh_hideEarthcaches" ${hideEarthcaches ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <svg id="gclh_hideVirtuals_svg">
+                                    <title>Virtuals</title>
+                                    <use href="#virtual"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-turquoise" id="gclh_hideVirtuals" ${hideVirtuals ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div style="grid-column: 5 / span 2;">
+                                <svg id="gclh_hideWebcams_svg">
+                                    <title>Webcams</title>
+                                    <use href="#webcam"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-turquoise" id="gclh_hideWebcams" ${hideWebcams ? 'checked' : ''} style="display:none">
+                            </div>
+                            <!-- Blue types -->
+                            <div>
+                                <svg id="gclh_hideLegendBlue_svg" style="width: 0.75em !important; margin-right: 0.5em;">
+                                    <title>All blue types</title>
+                                    <use href="#cache_icon_small_mystery"></use>
+                                </svg>
+                                <input type="checkbox" id="gclh_hideLegendBlue" ${hideLegendBlue ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <span id="gclh_separatorBlue" class="gclh_separator" style="width: 4px; height: 20px; background-color: #12508c; display: block;"></span>
+                            </div>
+                            <div>
+                                <svg id="gclh_hideMysteries_svg">
+                                    <title>Mysteries</title>
+                                    <use href="#mystery"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-blue" id="gclh_hideMysteries" ${hideMysteries ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div>
+                                <svg id="gclh_hideLetterboxes_svg">
+                                    <title>Letterboxes</title>
+                                    <use href="#letterbox"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-blue" id="gclh_hideLetterboxes" ${hideLetterboxes ? 'checked' : ''} style="display:none">
+                            </div>
+                            <div style="grid-column: 5 / span 2;">
+                                <svg id="gclh_hideWherigos_svg">
+                                    <title>Wherigos</title>
+                                    <use href="#wherigo"></use>
+                                </svg>
+                                <input type="checkbox" class="gclh-checkbox-blue" id="gclh_hideWherigos" ${hideWherigos ? 'checked' : ''} style="display:none">
+                            </div>
+                            <!-- Show/Hide all cache types -->
+                            <div style="grid-column: 1 / span 6;">
+                                <a class="no-underline hover:underline focus:underline" id="show_all_cachetypes" title="Show all cache types" href="#" style="margin-left: 0.5em;">Show all cache types</a>
+                            </div>
+                            <div style="grid-column: 1 / span 6;">
+                                <a class="no-underline hover:underline focus:underline" id="hide_all_cachetypes" title="Hide all cache types" href="#" style="margin-left: 0.5em;">Hide all cache types</a>
+                            </div>
+                        </div>
+                    `);
+
+                    // Remembered options.
+                    $list.append(`
+                        <br>
+                        <div style="margin-bottom: 5px;"><u>Remembered Display Options</u></div>
+                    `);
+                    // Show at corrected coordinates.
+                    $list.append(`
+                        <label for="gclh_showAtCorrectedCoords">
+                            <input type="checkbox" id="gclh_showAtCorrectedCoords" ${showAtCorrectedCoords ? 'checked' : ''}>
+                            Show finds at corrected coordinates
+                        </label>
+                    `);
+                    // Show cache type for DNFs.
+                    $list.append(`
+                        <label for="gclh_hideDNFIcons">
+                            <input type="checkbox" id="gclh_hideDNFIcons" ${hideDNFIcons ? 'checked' : ''}>
+                            Show cache type for DNFs
+                        </label>
+                    `);
 
                     // Open options on 'click'.
                     $("#gclh_display_options_control").click(function() {
-                        $("#gclh_display_options_list").css('display', 'block');
+                        const $optionsList = $('#gclh_display_options_list');
+                        // If options list is already open, do nothing.
+                        if ($optionsList.is(':visible')) return;
+
+                        $optionsList.show();
+
+                        // Show display options tooltip when opening options for the first time.
+                        if (getValue('set_switch_SM_show_options_tooltip', true)) {
+                            $("#gclh_options_info").click();
+                            setValue('set_switch_SM_show_options_tooltip', false);
+                        }
                     });
                     // Close options on 'mouseleave'.
                     $('.gclh_display_options_list').mouseleave(function() {
-                        $(this).css('display', 'none');
+                        $(this).hide();
+                        // Ensure that tooltip will be closed in any case.
+                        $('.gclh_options_info').hide();
+                        $('#gclh_options_info').css('opacity', 1);
                     });
 
-                    // Option handlers.
+                    // Open tooltip on 'click'.
+                    const opacity = 0.25;
+                    $("#gclh_options_info").click(function() {
+                        $('.gclh_options_info').show();
+                        $(this).css('opacity', opacity);
+                    });
+                    // Close tooltip on 'mouseleave'.
+                    $('.gclh_options_info').mouseleave(function() {
+                        $(this).hide();
+                        $('#gclh_options_info').css('opacity', 1);
+                    });
+
+                    // Handle clicks on status and type icons.
+                    function createTypeAndStatusClickHandlers(name,color) {
+                        $("#gclh_hide"+name+"_svg").click(function() {
+                            // Toggle checkbox.
+                            let checkbox = document.getElementById("gclh_hide"+name);
+                            checkbox.checked = !checkbox.checked;
+
+                            forceCachesRefresh();
+                            // Clear possible cache selection.
+                            unsafeWindow.MapSettings?.Map?.fireEvent('click');
+                            // Toggle state variable.
+                            eval('hide'+name+' = !hide'+name+';');
+                            updateFilterLegendStatus(color);
+                        });
+                    }
+                    // Handle clicks on legend icons.
+                    function createLegendClickHandlers(color) {
+                        $("#gclh_hideLegend"+color+"_svg").click(function () {
+                            // Toggle checkbox.
+                            let checkbox = document.getElementById("gclh_hideLegend"+color);
+                            checkbox.checked = !checkbox.checked;
+                            // Preserve current checkbox state (in case checkbox.checked toggles).
+                            let legendState = checkbox.checked;
+                            // If checked, all content must be checked, too. If unchecked, all must be unchecked.
+                            types[color].forEach(function(type,legendCheckbox) {
+                                let typeCheckbox = document.getElementById("gclh_hide" + type);
+                                if (typeCheckbox.checked !== legendState) {
+                                    $("#gclh_hide" + type + "_svg").trigger('click');
+                                }
+                            });
+
+                            forceCachesRefresh();
+                            // Clear possible cache selection.
+                            unsafeWindow.MapSettings?.Map?.fireEvent('click');
+                            // Toggle state variable.
+                            eval('hideLegend'+color+' = !hideLegend'+color+';');
+                        });
+                    }
+                    // Generate click handlers for legend and status/type icons.
+                    const types = {
+                        Gray: ['Finds','Owned','PastEvents'],
+                        Green: ['Tradis'],
+                        Orange: ['Multis'],
+                        Red: ['Events','Citos','Megas','Gigas'],
+                        Turquoise: ['Earthcaches','Virtuals','Webcams'],
+                        Blue: ['Mysteries','Letterboxes','Wherigos'],
+                    };
+                    for (const color in types) {
+                        // Legend icons.
+                        createLegendClickHandlers(color);
+                        // Status/Type icons.
+                        types[color].forEach(function(type) {
+                            createTypeAndStatusClickHandlers(type, color);
+                        });
+                    }
+
+                    // Handle clicks on corrected coords option.
                     $("#gclh_showAtCorrectedCoords").click(function() {
                         forceCachesRefresh();
                         // Clear possible cache selection.
                         unsafeWindow.MapSettings?.Map?.fireEvent('click');
+                        // Toggle state variable.
                         showAtCorrectedCoords = !showAtCorrectedCoords;
+                        // Save state.
                         setValue('set_switch_SM_show_at_corrected_coords', showAtCorrectedCoords);
                     });
+                    // Handle clicks on hide DNF icons option.
                     $("#gclh_hideDNFIcons").click(function() {
                         forceCachesRefresh();
                         // Clear possible cache selection.
                         unsafeWindow.MapSettings?.Map?.fireEvent('click');
+                        // Toggle state variable.
                         hideDNFIcons = !hideDNFIcons;
+                        // Save state.
                         setValue('set_switch_SM_hide_dnf_icons', hideDNFIcons);
                     });
 
-                    // Styles.
-                    let css = '';
-                    css += '.gclh_display_options_control > svg {height: 1.9em !important;}';
-                    css += '.gclh_display_options_list {display: none; position: absolute; right: 0px; top: 0px; width: max-content; border-radius: inherit; box-shadow: 0 1px 7px rgba(0,0,0,0.4); background-color: inherit; padding: 6px; z-index: 1000; color: black; font-family: "Noto Sans", Arial, Helvetica, sans-serif;}';
-                    css += '.gclh_display_options_list > label {display: flex; align-items: center; padding: 2px 2px; font-size: 13px; cursor: pointer;}';
-                    css += '.gclh_display_options_list > label:hover {background-color: #e6f7ef;}';
-                    css += '.gclh_display_options_list > label > input[type="checkbox"]:checked {accent-color: rgb(0 125 70);}';
+                    // Show all cache types.
+                    $('#show_all_cachetypes').click(function() {
+                        for (const color in types) {
+                            // Omit statuses.
+                            if (color === 'Gray') continue;
+                            const checkbox = document.getElementById("gclh_hideLegend"+color);
+                            // If checked, uncheck.
+                            if (checkbox?.checked) $("#gclh_hideLegend"+color+"_svg").trigger('click');
+                            // If unchecked, check and immediately uncheck again (this ensures that whole row is unchecked).
+                            else $("#gclh_hideLegend"+color+"_svg").trigger('click').trigger('click');
+                        }
+                    });
+                    // Hide all cache types.
+                    $('#hide_all_cachetypes').click(function() {
+                        for (const color in types) {
+                            // Omit statuses.
+                            if (color === 'Gray') continue;
+                            const checkbox = document.getElementById("gclh_hideLegend"+color);
+                            // If unchecked, check.
+                            if (!checkbox?.checked) $("#gclh_hideLegend"+color+"_svg").trigger('click');
+                        }
+                    });
+
+                    // Update view of legend icons according to state of included types/statuses.
+                    function updateFilterLegendStatus(color) {
+                        // All checkboxes of included types/statuses.
+                        const checkboxes = document.querySelectorAll('.gclh-checkbox-' + color.toLowerCase());
+                        // Check legend checkbox if and only if all included checkboxes are checked.
+                        const allChecked = Array.from(checkboxes).every(checkbox => checkbox.checked);
+                        document.getElementById("gclh_hideLegend" + color).checked = allChecked;
+
+                        // Invert button colors if any status or type is checked.
+                        const divs = document.querySelectorAll('div.gclh_grid_container > div');
+                        const checked = Array.from(divs).find(div => div.querySelector('input[type="checkbox"]:checked'));
+                        if (checked) {
+                            $('#gclh_display_options_control').addClass('bg-green-500');
+                            $('#gclh_display_options_control > svg').css('color', 'white');
+                        } else {
+                            $('#gclh_display_options_control').removeClass('bg-green-500');
+                            $('#gclh_display_options_control > svg').css('color', 'rgb(0, 178, 101)');
+                        }
+                    };
+
+                    // Styling.
+                    const css = `
+                    .gclh_display_options_control > svg {
+                        height: 1.9em !important;
+                    }
+                    .gclh_display_options_list {
+                        max-height: 65vh;
+                        overflow-y: auto;
+                        display: none;
+                        position: absolute;
+                        right: 0;
+                        top: -15vh;
+                        width: max-content;
+                        border-radius: inherit;
+                        box-shadow: 0 1px 7px rgba(0,0,0,0.4);
+                        background-color: white;
+                        padding: 15px;
+                        z-index: 1000;
+                        color: black;
+                        font-family: "Noto Sans", Arial, Helvetica, sans-serif;
+                        font-size: 14px;
+                        cursor: default;
+                        text-align: left;
+                        user-select: text;
+                    }
+                    .gclh_display_options_list > label {
+                        display: flex;
+                        align-items: center;
+                        padding: 2px 2px;
+                        font-size: 14px !important;
+                    }
+                    .gclh_display_options_list > label:hover {
+                        background-color: #e6f7ef;
+                        cursor: pointer;
+                    }
+                    .gclh_display_options_list > label > input[type="checkbox"]:checked {
+                        accent-color: rgb(0 125 70);
+                    }
+                    .gclh_display_options_list svg {
+                        width: 1.5em !important;
+                        height: 1.5em !important;
+                        margin-left: 0.5em;
+                        margin-right: 0.5em;
+                    }
+                    .gclh_display_options_list svg:hover {
+                        cursor: pointer;
+                    }
+                    .gclh_grid_container {
+                        display: grid !important;
+                        grid-template-columns: 25px 4px 30px 30px 30px 90px;
+                        justify-items: start;
+                    }
+                    .gclh_grid_container > div:has(input[type="checkbox"]:checked) {
+                        opacity: ${opacity};
+                    }
+                    .gclh_grid_container > div:has(input[type="checkbox"]:checked) + div .gclh_separator {
+                        opacity: ${opacity};
+                    }
+                    .gclh_options_info {
+                        display: none;
+                        position: absolute;
+                        right: 5px;
+                        top: 45px;
+                        width: 280px;
+                        border-radius: inherit;
+                        box-shadow: 0 1px 7px rgba(0,0,0,0.4);
+                        background-color: inherit;
+                        padding: 15px;
+                        z-index: 1001;
+                        color: black;
+                        font-family: "Noto Sans", Arial, Helvetica, sans-serif;
+                        font-size: 14px;
+                        cursor: default;
+                        text-align: left;
+                    }
+                    `;
                     appendCssStyle(css);
                 });
             }
 
             // Add button for additional geocache display options.
             if (settings_searchmap_show_cache_display_options && settings_use_gclh_layercontrol && settings_use_gclh_layercontrol_on_search_map) {
+                var hideFinds = false;
+                var hideOwned = false;
+                var hidePastEvents = false;
+                var hideTradis = false;
+                var hideMultis = false;
+                var hideEvents = false;
+                var hideCitos = false;
+                var hideMegas = false;
+                var hideGigas = false;
+                var hideEarthcaches = false;
+                var hideVirtuals = false;
+                var hideWebcams = false;
+                var hideMysteries = false;
+                var hideLetterboxes = false;
+                var hideWherigos = false;
+                var hideLegendGray = false;
+                var hideLegendGreen = false;
+                var hideLegendOrange = false;
+                var hideLegendRed = false;
+                var hideLegendTurquoise = false;
+                var hideLegendBlue = false;
                 var showAtCorrectedCoords = getValue('set_switch_SM_show_at_corrected_coords', false);
                 var hideDNFIcons = getValue('set_switch_SM_hide_dnf_icons', false);
+
                 // Add button with small delay to ensure it is always at the top (necessary for FF).
-                setTimeout(cacheDisplayOptionsButton, 0);
+                setTimeout(addCacheDisplayOptionsButton, 0);
             }
 
             // Handle enabling/disabling display options button.
             function addEnableDisableDisplayOptionsHandler() {
                 if (document.querySelector('button[data-testid="list-mode-toggle"]')) {
-                    if (!$('ul[data-testid="mode-toggles"]').hasClass('gclh-mode-toggles')) {
-                        $('ul[data-testid="mode-toggles"]').addClass('gclh-mode-toggles');
-                        // Disable button for BML.
-                        $('button[data-testid="list-mode-toggle"]').click(function() {
-                            document.querySelector('#gclh_display_options_control')?.setAttribute('disabled', '');
-                        });
-                    }
-                    // Enable button when returning to search list.
-                    if (document.querySelector('li.bg-green-500[data-testid="search-mode-item"]') &&
-                        document.querySelector('#gclh_display_options_control')?.hasAttribute('disabled')) {
-                        document.querySelector('#gclh_display_options_control').removeAttribute('disabled');
-                        // Reinitialize map bounds.
-                        [latHighG, latLowG, lngHighG, lngLowG] = getMapBounds();
-                        // Disable 'moveend' and 'zoomend' event handlers.
-                        moveend_zoomend = false;
+                    // Returning to search list.
+                    if (document.querySelector('li.bg-green-500[data-testid="search-mode-item"]')) {
+                        if ($('#gclh_display_options_control').hasClass('gclh-bml')) {
+                            $('#gclh_display_options_control').removeClass('gclh-bml');
+                            moveend_zoomend = false;
+
+                            // Run box search s.t. results match map view.
+                            setTimeout(() => {
+                                $('[data-event-label="Map - Search This Area"]').first().click();
+                            },1000);
+                        }
                     } else {
+                        if (getURLParam('bmCode')) {
+                            $('#gclh_display_options_control').addClass('gclh-bml');
+                            forceCachesRefresh();
+                        }
                         // Ensure proper zooming in BML by enabling 'moveend' and 'zoomend' event handlers.
                         moveend_zoomend = true;
                     }
@@ -10894,7 +11424,7 @@ var mainGC = function() {
                     $('button[data-testid="search-button"]').click(() => {
                         filterSearchWasRunning = true;
                     });
-                });
+                }, 10000);
 
                 // Unset blocker variables if any search is finished (trigger: zoom buttons disabled/enabled).
                 waitForElementThenRun('[data-event-label="Map - Zoom In"]', () => {
@@ -16593,7 +17123,7 @@ var mainGC = function() {
             html += checkboxy('settings_show_eventdayX0', 'Show weekday of an event') + show_help("With this option the day of the week will be displayed next to the event date.") + "<br>";
 //xxxx
             html += newParameterOn1;
-            html += checkboxy('settings_searchmap_show_cache_display_options', 'Show button for additional geocache display options') + show_help("With this option you can show a button for additional geocache display options on Search Map, e.g. show geocaches at corrected coordinates or hide DNFs.<br><br>This feature requires <a class='gclh_ref_ht_int' href=\"#settings_use_gclh_layercontrol_on_search_map\" title='Link to setting \"Replace map layers\"'>Replace map layers in Search Map</a> to be activated.") + onlySearchMap + "<br>";
+            html += checkboxy('settings_searchmap_show_cache_display_options', 'Show button for additional geocache display options') + show_help("With this option you can show a button for additional geocache display options on Search Map, e.g. show finds at corrected coordinates, hide DNFs or filter cache types.<br><br>This feature requires <a class='gclh_ref_ht_int' href=\"#settings_use_gclh_layercontrol_on_search_map\" title='Link to setting \"Replace map layers\"'>Replace map layers in Search Map</a> to be activated.") + onlySearchMap + "<br>";
             html += newParameterVersionSetzen('0.17') + newParameterOff;
             html += checkboxy('settings_searchmap_improve_add_to_list', 'Show compact layout in \"Add to list\" pop up to bookmark a cache') + onlySearchMap + prem + "<br>";
             html += " &nbsp; &nbsp;" + "Maximum height of pop up <select class='gclh_form' id='settings_searchmap_improve_add_to_list_height' >";


### PR DESCRIPTION
More display options for search results on search map:
- hide by status: finds, owned, DNFs, past events
- hide by type: all available cache types

Layout of the options dialog is similar to the one in browse map:

<img width="462" height="556" alt="image" src="https://github.com/user-attachments/assets/e5757fd9-25ad-4ea3-8ad3-6074a817e266" />