### PR TITLE
[Browse Map] Overflow in long cache names and owner names in popup.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -12962,7 +12962,7 @@ var mainGC = function() {
             css += "span.premium_only img {margin-right:0px;}";
             css += "#ownBMLsCount {cursor: default;} .map-item .send2gps img {margin-right: 0px;}";
             css += ".LogTotals, .LogTotals li {display: inline-block; margin: 0;} .LogTotals li {margin-right: 5px;}";
-            if (browser == 'firefox') css += ".gclh_owner {max-width: 110px;} .map-item h4 a {max-width: 265px;} .gclh_owner, .map-item h4 a {display: inline-block; white-space: nowrap; overflow: -moz-hidden-unscrollable; text-overflow: ellipsis;}";
+            css += ".gclh_owner {max-width: 110px;} .map-item h4 a {max-width: 265px;} .gclh_owner, .map-item h4 a {display: inline-block; white-space: nowrap; overflow: clip; text-overflow: ellipsis;}";
             appendCssStyle(css);
 
             // Create an observer instance.


### PR DESCRIPTION
Overflow in long cache names and owner names in the browse map popup.

Long cache names:
![Anmerkung 1](https://github.com/user-attachments/assets/5d6097d5-404c-4753-8237-e0dc9f4df7a1)

Long owner names:
![Anmerkung 2](https://github.com/user-attachments/assets/3d38b555-32be-4180-be2b-db05b421ef7f)

In addition, the length limit was previously only active for Firefox, but is now active for all browsers.