### PR TITLE
[Search Map] Fix error caused by too many calls to History API

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -11386,7 +11386,16 @@ var mainGC = function() {
             window.history.pushState = new Proxy(window.history.pushState, {
                 apply: (target, thisArg, argArray) => {
                     setZoom();
-                    return target.apply(thisArg, argArray);
+
+                    // FF issue (https://github.com/2Abendsegler/GClh/issues/2889):
+                    // "Too many calls to Location or History APIs in a short period of time" results in an exception
+                    // and therefore gclh code stops. This exception is catched here and logged as a warning.
+                    // Not an issue in Chrome.
+                    try {
+                        return target.apply(thisArg, argArray);
+                    } catch(e) {
+                        console.warn(e);
+                    }
                 }
             });
 


### PR DESCRIPTION
Fix consequential error of `Too many calls to Location or History APIs within a short timeframe` in Firefox (#2889).

In Firefox, if `Too many calls to Location or History APIs within a short timeframe` occurs, then an exception will be thrown.
As a consequence, gclh code execution stops and can have side effects (as described in the mentioned issue).

The fix catches this exception and logs it as a warning.

Since this issue cannot be reproduced, the cause of the occurrences of `Too many calls to Location or History APIs within a short timeframe` in the user's environment remains unknown and we can only fix the symptoms.

This isn't a general issue, is Firefox specific (Chrome-based browsers don't throw an exception) and the fix is safe in all environments.

Developer note:
The issue can be forced by running this code snippet in Firefox console:
``` javascript
count = 1;
maxCalls = 500;
interval = 5;

intervalId = setInterval(() => {
    if (count < maxCalls) {
        try {
            window.history.pushState({ id: count }, `Title ${count}`, `url${count}`);
            count++;
        } catch (e) {
            console.error(e);
            clearInterval(intervalId);
        }
    } else {
        clearInterval(intervalId);
    }
}, interval);
```


