### PR TITLE
[New Dashboard] Option to hide/show the right sidebar

### DIFF
--- a/data/config_standard.txt
+++ b/data/config_standard.txt
@@ -392,6 +392,7 @@
   "settings_hide_own_tbs_log_form": false,
   "settings_hide_share_log_button_log_view": false,
   "settings_dashboard_hide_tb_activity": false,
+  "settings_dashboard_hide_right_sidebar": false,
   "settings_button_sort_tbs_by_name_log_form": true,
   "settings_larger_content_width_log_form": true,
   "settings_less_space_log_lines_log_form": true,

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -753,6 +753,7 @@ var variablesInit = function(c) {
     c.settings_hide_own_tbs_log_form = getValue("settings_hide_own_tbs_log_form", false);
     c.settings_hide_share_log_button_log_view = getValue("settings_hide_share_log_button_log_view", false);
     c.settings_dashboard_hide_tb_activity = getValue("settings_dashboard_hide_tb_activity", false);
+    c.settings_dashboard_hide_right_sidebar = getValue("settings_dashboard_hide_right_sidebar", false);
     c.settings_button_sort_tbs_by_name_log_form = getValue("settings_button_sort_tbs_by_name_log_form", true);
     c.settings_larger_content_width_log_form = getValue("settings_larger_content_width_log_form", true);
     c.settings_less_space_log_lines_log_form = getValue("settings_less_space_log_lines_log_form", true);
@@ -9972,6 +9973,52 @@ var mainGC = function() {
 
             // Latest Activity: Do not cut avatar image.
             css += '.activity-details > div > a {flex-shrink: 0;}';
+
+            // Hide right sidebar ("Events nearby" and "Geocaches nearby").
+            waitForElementThenRun('div.sidebar-right', function() {
+                const $layoutFeed = $('#LayoutFeed');
+                const $layoutFeed_max_width = $layoutFeed.css('max-width');
+                const $sidebar_right = $('div.sidebar-right');
+                const $sidebar_right_max_width = $sidebar_right.css('max-width');
+                $sidebar_right.css('width', $sidebar_right_max_width);
+                const $wrapper = $('<div>', {
+                    id: 'gclh_right_sidebar_wrapper',
+                    height: 'fit-content'
+                });
+                $sidebar_right.wrap($wrapper);
+                if (settings_dashboard_hide_right_sidebar) $sidebar_right.hide();
+
+                const title_hide = 'Click to hide all sections on the right side';
+                const title_show = 'Click to show all sections on the right side';
+                const $btn = $('<button>', {
+                    id: 'gclh_right_sidebar_toggle',
+                    type: 'button',
+                    title: (settings_dashboard_hide_right_sidebar ? title_show : title_hide)
+                }).html(`
+                  <svg style="transform: ${settings_dashboard_hide_right_sidebar ? 'rotate(90deg)' : 'rotate(-90deg)'};">
+                    <use xlink:href="/account/app/ui-icons/sprites/global.svg#icon-expand-svg-fill"></use>
+                  </svg>`);
+                $sidebar_right.before($btn);
+
+                const $svg = $btn.find('svg');
+                $btn.click(function() {
+                    if ($sidebar_right.is(':visible')) {
+                        $sidebar_right.hide('fast');
+                        $svg.css('transform', 'rotate(90deg)');
+                        $layoutFeed.css('max-width', 'none');
+                        $btn.attr('title', title_show);
+                    } else {
+                        $sidebar_right.show('fast');
+                        $svg.css('transform', 'rotate(-90deg)');
+                        $layoutFeed.css('max-width', $layoutFeed_max_width);
+                        $btn.attr('title', title_hide);
+                    }
+                });
+
+                css += '#gclh_right_sidebar_toggle {position: absolute; margin-left: -19px; margin-top: 8px; padding: 0; border: none; cursor: pointer; background-color: unset;}';
+                css += '#gclh_right_sidebar_toggle svg {height: 18px; width: 18px; pointer-events: none;}';
+            });
+
             appendCssStyle(css);
         } catch(e) {gclh_error("Improve new dashboard",e);}
     }
@@ -17445,6 +17492,9 @@ var mainGC = function() {
             html += newParameterOn2;
             html += checkboxy('settings_dashboard_hide_tb_activity', 'Hide all trackable logs in the Latest Activity') + "<br>";
             html += newParameterVersionSetzen('0.15') + newParameterOff;
+            html += newParameterOn1;
+            html += checkboxy('settings_dashboard_hide_right_sidebar', 'Hide "Events nearby" and "Geocaches nearby" by default') + show_help('This option allows you to hide “Events nearby” and “Geocaches nearby” in the right sidebar by default.') + "<br>";
+            html += newParameterVersionSetzen('0.17') + newParameterOff;
 
             html += "<div class='gclh_old_new_line'>Old Dashboard Only</div>";
             html += checkboxy('settings_hide_visits_in_profile', 'Hide trackable visits on your dashboard') + "<br>";
@@ -19296,6 +19346,7 @@ var mainGC = function() {
                 'settings_hide_own_tbs_log_form',
                 'settings_hide_share_log_button_log_view',
                 'settings_dashboard_hide_tb_activity',
+                'settings_dashboard_hide_right_sidebar',
                 'settings_button_sort_tbs_by_name_log_form',
                 'settings_larger_content_width_log_form',
                 'settings_less_space_log_lines_log_form',


### PR DESCRIPTION
New option to hide/show the right sidebar:  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/73c7c72c-2e36-451f-88d8-87c753c0837c" />


This will hide the right sidebar, including "Events nearby" and "Geocaches nearby", and use the additional space for the "Latest Activity" section.

There's also a config paramter to hide it by default.

From my point of view and the feedback in [GS forum](https://forums.geocaching.com/GC/index.php?/topic/431925-release-notes-website-old-dashboard-retirement-coming-soon-february-3-2026/) this seems like a resonable and helpful addition.