### PR TITLE
[New Dashboard] Unpublished hides are missing

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -9800,7 +9800,7 @@ var mainGC = function() {
             // Show unpublished hides.
             if (settings_showUnpublishedHides) {
                 function waitForGeocachesNearbyContainer(waitCount) {
-                    if ($('#_GeocachesNearbyContainer')[0] && $('#_GeocachesNearbyContainer svg')[0]) {
+                    if ($('#sidebarNavigation > nav')[0] && $('#_GeocachesNearbyContainer svg')[0]) {
                         var panel = '<div id="gclh_unpublishedCaches" class="panel collapsible">';
                         panel += '    <div class="panel-header isActive">';
                         panel += '        <h1 class="h5 no-margin">Unpublished Hides</h1>';
@@ -9828,8 +9828,8 @@ var mainGC = function() {
                                 setValue('unpublishedCaches_visible', true);
                             }
                         });
-                        // If the link to unpublished hides is shown in dashboard, there are some.
-                        if ($('a.bold[href="/account/dashboard/unpublishedcaches"]')[0]) {
+                        // If the link to unpublished hides is shown in bold, there are some.
+                        if ($('a[href*="/play/owner/unpublished"]:has(> strong)')[0]) {
                             // Build the area to list the unpublished caches and events.
                             function buildListArea() {
                                 if ($('#gclh_unpublishedCaches_list')[0]) return;


### PR DESCRIPTION
If option `Show unpublished caches on your dashboard` is active, no unpublished caches are shown (even if unpublished caches are available):

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9459afcc-b9c6-48ef-8704-37c34930ccfd" />

Reason is a changed link to the owner's unpublished hides.

This MR also ensures that the link to the owner's unpublished hides is available before the function starts (asynchronous loading). In Chrome-based browsers it could happen that the function ran too early.