### PR TITLE
[New Log Form] Word count not correct when using special characters.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -4902,7 +4902,8 @@ var mainGC = function() {
                     // Count words.
                     $('.character-limit').append('<span class="gclh_word_count"></span>');
                     $('#gc-md-editor_md').bind('input', (e) => {
-                        let words = e.target.value.split(/[^\w]/).filter(w => w.match(/\w+/)).length;
+                        // "filter(Boolean)" filtered empty content.
+                        let words = e.target.value.trim().split(/\s+/).filter(Boolean).length;
                         $('.gclh_word_count').html(`&nbsp;(${words})`);
                     });
                 }

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -4902,8 +4902,8 @@ var mainGC = function() {
                     // Count words.
                     $('.character-limit').append('<span class="gclh_word_count"></span>');
                     $('#gc-md-editor_md').bind('input', (e) => {
-                        // "filter(Boolean)" filtered empty content.
-                        let words = e.target.value.trim().split(/\s+/).filter(Boolean).length;
+                        // (For details and explanations see https://github.com/2Abendsegler/GClh/pull/2958.)
+                        let words = e.target.value.trim().split(/\s+/).filter(Boolean).filter(token => /[\p{L}\p{N}\p{Extended_Pictographic}]/u.test(token)).length;
                         $('.gclh_word_count').html(`&nbsp;(${words})`);
                     });
                 }


### PR DESCRIPTION
close #2957

`let words = e.target.value.split(/[^\w]/).filter(w => w.match(/\w+/)).length;`
Bisher werden hiermit lediglich Zeichen aus dem lateinischen Alphabet als Teil eines Wortes erkannt. Ist inmitten eines Wortes ein Zeichen, das nicht im lateinischen Alphabet enthalten ist, wird das Zeichen quasi wie eine Unterbrechung des Wortes behandelt. Fälschlich werden dabei also zwei Worte gezählt. Beispiele im Deutschen sind `ä ö ü ß` oder im Französischen `é è`. Logographische Zeichen wie beispielsweise japanische oder koreanische Schriftzeichen werden gar nicht als Bestandteil eines Wortes erkannt. Beispielsweise sollten hierbei 7 Worte gezählt werden `그녀는 이탈리아를 좋아하기 때문에 자주 파스타를 요리한다`. 
  
`let words3 = e.target.value.trim().split(/\s+/).filter(Boolean).length;`
(Edit: "filter(Boolean)" filtered empty content.)
Damit wären die oben genannten Probleme behoben. 

Allerdings zählt nun beispielsweise auch ein Gedankenstrich zwischen zwei Worten als ein zusätzliches Wort. Beispielsweise würden bei `Er kommt - wie immer - zu spät.` 8 Worte anstatt 6 gezählt. Darüber hinaus sind mir keine echten negativen Beispiele eingefallen, die in der regulären Schreibweise verwendet werden. Man könnte natürlich auch vor einem Punkt oder einem Komma einen Blank einbauen, aber das entspricht nicht der regulären Schreibweise.
Den Gedankenstrich könnte man ja eliminieren.
