### PR TITLE
[New Dashboard] Improve and fix sorting of unpublished caches

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -20705,16 +20705,13 @@ var mainGC = function() {
 
 // Sort functions for unpublished in Dashboard.
     function abc(a, b) {
-        var sort = $(a)[0].name < $(b)[0].name ? -1 : $(b)[0].name < $(a)[0].name ? 1 : 0;
-        return sort;
+        return a.name.localeCompare(b.name, undefined, {'numeric': true });
     }
     function gcOld(a, b) {
-        var sort = $(b)[0].referenceCode < $(a)[0].referenceCode ? -1 : $(a)[0].referenceCode < $(b)[0].referenceCode ? 1 : 0;
-        return sort;
+        return a.referenceCode.localeCompare(b.referenceCode);
     }
     function gcNew(a, b) {
-        var sort = $(a)[0].referenceCode < $(b)[0].referenceCode ? -1 : $(b)[0].referenceCode < $(a)[0].referenceCode ? 1 : 0;
-        return sort;
+        return b.referenceCode.localeCompare(a.referenceCode);
     }
 
 // Trim.


### PR DESCRIPTION
Improvement and fix for the sorting of unpublished hides:
1. Alphabetical sorting now also considers numbers in cache names<img width="400" alt="image" src="https://github.com/user-attachments/assets/6da67b44-c5a7-40a8-9aba-a279b0218b47" />
2. Sorting by GC code now works properly (before, oldest/newest first were swapped), e.g. oldest first<img width="400" alt="image" src="https://github.com/user-attachments/assets/78d4aff0-238e-4514-a6b7-811098b47826" />

