### PR TITLE
[New Dashboard] Fix border for unpublished events

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -9934,7 +9934,7 @@ var mainGC = function() {
                                 }
                                 $('#gclh_unpublishedCaches_cachesList').html(list);
                                 if ($('#gclh_unpublishedCaches_eventsList li')[0]) {
-                                    $('#gclh_unpublishedCaches_cachesList li:last')[0].setAttribute('style', 'border-bottom: 1px solid #e4e4e4 !important;');
+                                    $('#gclh_unpublishedCaches_eventsList li')[0].setAttribute('style', 'border-top: 1px solid #e4e4e4;');
                                 }
                             }
                             // Build the list of unpublished events.
@@ -9973,7 +9973,7 @@ var mainGC = function() {
                                 }
                                 $('#gclh_unpublishedCaches_eventsList').html(list);
                                 if ($('#gclh_unpublishedCaches_cachesList li')[0]) {
-                                    $('#gclh_unpublishedCaches_eventsList li:last')[0].setAttribute('style', 'border-top: 1px solid #e4e4e4 !important;');
+                                    $('#gclh_unpublishedCaches_eventsList li')[0].setAttribute('style', 'border-top: 1px solid #e4e4e4;');
                                 }
                             }
                             // Get a list of unpublished caches via api.


### PR DESCRIPTION
If both, unpublished caches and events are available, then one border is missing at the topmost event:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/6a4f4084-01e6-4907-ba4b-ac74dde51eee" />
