### PR TITLE
[New Dashboard] Unpublished event dates follow user setting

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -9948,7 +9948,13 @@ var mainGC = function() {
                                     let eventStartTime = events[i].eventStartTime;
                                     // Date and time format: window.navigator.language: There is the preferred language in the browser for displaying pages.
                                     let date = new Date(eventStartTime);
-                                    let startDate = date.toLocaleDateString(window.navigator.language, {year: 'numeric', month: '2-digit', day: '2-digit'})
+                                    let startDate;
+                                    try {
+                                        const jqui_date_format = unsafeWindow.serverParameters["user:info"].dateFormat.replace(/yy/g, 'y').replace(/M/g, 'm').replace(/mmm/, 'M');
+                                        startDate = $.datepicker.formatDate(jqui_date_format, date);
+                                    } catch {
+                                        startDate = date.toLocaleDateString(window.navigator.language, {year: 'numeric', month: '2-digit', day: '2-digit'});
+                                    }
                                     let startTime = date.toLocaleTimeString(window.navigator.language, {hour: '2-digit', minute: '2-digit'});
                                     list += '<li class="activity-item activity-item-head">';
                                     list += '    <div class="activity-type-icon">';


### PR DESCRIPTION
Dates of unpublished events now follow the GS user setting:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/e6968f71-47bf-411f-aa5a-bb5867847996" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/4da003b1-7a98-400e-86d9-d9fe328bb18a" />
 