### PR TITLE
[Profile] Count of trackables is splitting.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -14152,6 +14152,7 @@ var mainGC = function() {
             }
             if ($('#ctl00_ContentBody_ProfilePanel1_dlCollectibles')[0]) gclh_coin_stats("ctl00_ContentBody_ProfilePanel1_dlCollectibles");
             if ($('#ctl00_ContentBody_ProfilePanel1_dlCollectiblesOwned')[0]) gclh_coin_stats("ctl00_ContentBody_ProfilePanel1_dlCollectiblesOwned");
+            appendCssStyle(".Table .AlignRight {word-break: normal !important;}");
         } catch(e) {gclh_error("Show Coin-Sums",e);}
     }
 


### PR DESCRIPTION
An example is provided here: 
https://www.geocaching.com/p/default.aspx?u=Pe_Bo&tab=trackables#profilepanel

---
Bug:

![Screenshot 1](https://github.com/user-attachments/assets/c0d983cc-8afe-4b23-bcf4-b31034e78fc8)

![Screenshot 2](https://github.com/user-attachments/assets/67d045c7-fc0e-4c3b-8b65-c6d9633f3118)

---
Correction:

![Screenshot 3](https://github.com/user-attachments/assets/e3133118-dd96-4b75-b18b-bca22d6eaa45)

![Screenshot 4](https://github.com/user-attachments/assets/7bf00064-f15c-43a8-b129-e5f1e0598711)
