### PR TITLE
[Search Trackables] Extension of feature to dim lost trackables for owned trackables view to search trackables view.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13483,7 +13483,7 @@ var mainGC = function() {
         } catch(e) {gclh_error("Trackable map resizing and zooming with mouse wheel",e);}
     }
 
-// Dimmed style for lost trackabels on owned trackables view and trackables search view.
+// Dimmed style for lost trackabels on owned trackables view and search trackables view.
     if (document.location.href.match(/\.com\/track\/search\.aspx/) && settings_dim_lost_trackables) {
         try {
             const $rows = $('table.Table td:nth-child(5)').not(':has(img[src^="/images/"])').closest('tr');

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -17300,7 +17300,7 @@ var mainGC = function() {
             html += checkboxy('settings_improve_notifications', 'Improve notification list and notifications') + "<br>";
             html += newParameterVersionSetzen('0.15') + newParameterOff;
             html += newParameterOn1;
-            html += checkboxy('settings_dim_lost_trackables', 'Dim lost trackables in owned and search trackables view') + show_help("Lost trackables in owned trackables view and search trackables view can be visually dimmed so they are easier to distinguish from active trackables.") + "<br>";
+            html += checkboxy('settings_dim_lost_trackables', 'Dim lost trackables in "Search Trackables" result view') + show_help("Lost trackables in \"Search Trackables\" result view can be visually dimmed so they are easier to distinguish from active trackables.") + "<br>";
             html += newParameterVersionSetzen('0.17') + newParameterOff;
             html += "</div>";
 

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13483,8 +13483,8 @@ var mainGC = function() {
         } catch(e) {gclh_error("Trackable map resizing and zooming with mouse wheel",e);}
     }
 
-// Dimmed style for lost trackabels on owned trackables view.
-    if (document.location.href.match(/\.com\/track\/search\.aspx\?o=1&uid=/) && settings_dim_lost_trackables) {
+// Dimmed style for lost trackabels on owned trackables view and trackables search view.
+    if (document.location.href.match(/\.com\/track\/search\.aspx/) && settings_dim_lost_trackables) {
         try {
             const $rows = $('table.Table td:nth-child(5)').not(':has(img[src^="/images/"])').closest('tr');
             $rows.find('td, a').css({ color: '#AFAFAF', textDecoration: 'line-through' });
@@ -17300,7 +17300,7 @@ var mainGC = function() {
             html += checkboxy('settings_improve_notifications', 'Improve notification list and notifications') + "<br>";
             html += newParameterVersionSetzen('0.15') + newParameterOff;
             html += newParameterOn1;
-            html += checkboxy('settings_dim_lost_trackables', 'Dim lost trackables in owned trackables view') + show_help("Lost trackables in owned trackables view can be visually dimmed so they are easier to distinguish from active trackables.") + "<br>";
+            html += checkboxy('settings_dim_lost_trackables', 'Dim lost trackables in owned and search trackables view') + show_help("Lost trackables in owned trackables view and search trackables view can be visually dimmed so they are easier to distinguish from active trackables.") + "<br>";
             html += newParameterVersionSetzen('0.17') + newParameterOff;
             html += "</div>";
 


### PR DESCRIPTION
Related to #2844
Extension of feature to dim lost trackables for owned trackables view to search trackables view.

I wasn't quite sure what to use as the config parameter name and description.

Example for a search trackable view:
![Screenshot tbs](https://github.com/user-attachments/assets/804e48bd-d680-49cf-a49a-f9af55a79c9a)

---
To reproduce:
1. https://www.geocaching.com/track/search.aspx
2. Enter a Username
3. Click button Go