### PR TITLE
[Profile] "Use old links to finds and hides caches" no longer works for the links in the cache types.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -14362,7 +14362,7 @@ var mainGC = function() {
         // All hides.
         if ($('.hides-col-header .minorDetails a')[0]) $('.hides-col-header .minorDetails a')[0].href = '/seek/nearest.aspx?u='+urlencode($('#ctl00_ProfileHead_ProfileHeader_lblMemberName')[0].innerHTML);
         $('.finds-col table tbody tr a, .hides-col table tbody tr a').each(function() {
-            let match = /\/play\/results\?ct=(\d+).*&(fb|hb)=.*/gi.exec(this.href);
+            let match = /\/play\/search\?ct=(\d+).*&(fb|hb)=.*/gi.exec(this.href);
             if (match) {
                 let [_full, type, foundOrHide] = match;
                 foundOrHide = foundOrHide == 'fb' ? 'ul' : 'u';


### PR DESCRIPTION
Use old links to finds and hides caches no longer works for the links in the cache types.

Bug:
![Zwischenablage01](https://github.com/user-attachments/assets/99495144-1b6e-453f-b830-89283450c93f)

---
Correction:
![Zwischenablage02](https://github.com/user-attachments/assets/96b5a9b8-0b87-4b9c-a9a2-2f5cf4548422)
