### PR TITLE
[New Dashboard] Stop the expand icons in VIP, VUP lists from flickering

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -7941,6 +7941,8 @@ var mainGC = function() {
                     } else {waitCount++; if (waitCount <= 200) setTimeout(function(){waitForLeftSidebarVip(waitCount);}, 50);}
                 }
                 waitForLeftSidebarVip(0);
+                // To stop the expand icon from flickering because the actual CSS is built later.
+                buildDashboardCss();
 
             // Friends list:
             // ----------


### PR DESCRIPTION
Stop the expand icons in VIP, VUP lists in dashboard from flickering because the actual CSS is built later.