### PR TITLE
[Pocket Query] Prevent map error after PQ deletion

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -6481,6 +6481,9 @@ var mainGC = function() {
 // Map on create pocket query page.
     if (settings_pq_previewmap && document.location.href.match(/\.com\/pocket\/gcquery\.aspx/) && !global_isBasic) {
         try {
+            // If a PQ is deleted, then the page gets reloaded empty and therefore no map needed.
+            if (!$('.LatLongTable')[0]) return;
+
             leafletInit();
             $('.LatLongTable').after('<div style="position:absolute;top: 8px; left: 300px;height:330px;width:470px;" id="gclh_map" ></div>').parent().css("style", "relative");
             var previewMap = L.map('gclh_map', {


### PR DESCRIPTION
If a pocket query is deleted and parameter `settings_pq_previewmap` is active, then an error occurs:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/1809a2b9-524d-4832-afd8-3773dfe53ced" />

Reason is that after pq deletion the page gets reloaded empty and therefore no map container can be added.
