### PR TITLE
[Cache Listing] Personal cache note templates - linebreaks in hints.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3595,7 +3595,7 @@ var mainGC = function() {
                             }
                         }
                         aHints = aHints.replace(/<br>/g, '\r\n');
-                        aHints = JSON.stringify(aHints);
+                        aHints = JSON.stringify(aHints).slice(1, -1);
                         var code = "function gclh_insert_tpl(id){";
                         code += "  document.getElementById('gclh_cache_note_tpls').value = -1;";
                         code += "  var input = document.getElementById('cacheNoteText');";
@@ -3606,7 +3606,7 @@ var mainGC = function() {
                         code += "  inhalt = inhalt.replace(/\\&amp\\;/g,'&');";
                         code += "  if (aDate) inhalt = inhalt.replace(/#Date#/ig, aDate);";
                         code += "  if (aTime) inhalt = inhalt.replace(/#Time#/ig, aTime);";
-                        code += "  inhalt = inhalt.replace(/#Hints#/ig, aHints.replace(/(^\"|\"$)/g,''));";
+                        code += "  inhalt = inhalt.replace(/#Hints#/ig, aHints);";
                         code += "  if (typeof input.selectionStart != 'undefined' && inhalt) {";
                         code += "    var start = input.selectionStart;";
                         code += "    var end = input.selectionEnd;";

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3594,6 +3594,8 @@ var mainGC = function() {
                                 aHints = $('#div_hint')[0].innerHTML.trim();
                             }
                         }
+                        aHints = aHints.replace(/<br>/g, '\r\n');
+                        aHints = JSON.stringify(aHints);
                         var code = "function gclh_insert_tpl(id){";
                         code += "  document.getElementById('gclh_cache_note_tpls').value = -1;";
                         code += "  var input = document.getElementById('cacheNoteText');";
@@ -3604,7 +3606,7 @@ var mainGC = function() {
                         code += "  inhalt = inhalt.replace(/\\&amp\\;/g,'&');";
                         code += "  if (aDate) inhalt = inhalt.replace(/#Date#/ig, aDate);";
                         code += "  if (aTime) inhalt = inhalt.replace(/#Time#/ig, aTime);";
-                        code += "  inhalt = inhalt.replace(/#Hints#/ig, aHints);";
+                        code += "  inhalt = inhalt.replace(/#Hints#/ig, aHints.replace(/(^\"|\"$)/g,''));";
                         code += "  if (typeof input.selectionStart != 'undefined' && inhalt) {";
                         code += "    var start = input.selectionStart;";
                         code += "    var end = input.selectionEnd;";


### PR DESCRIPTION
Related to #2705

In den Personal cache note templates gibt es noch zwei Probleme, die hiermit korrigiert werden sollen.

---
1. In Hints mit Zeilenumbruch kommt es zu einem Error. Das soll hier korrigiert werden. Außerdem soll dieser Zeilenumbruch über den Parameter `#Hints#` korrekt dargestellt werden.
Error: `Uncaught SyntaxError: '' string literal contains an unescaped line break`
Beispiel: https://coord.info/GCBBPP2
Der Zeilenumbruch wird in den `Additional hints` seit einiger Zeit nur noch mit einem Blank dargestellt. Im Beispiel ist zwischen `Stützpfähle` und `Final` ein Zeilenumbruch. Im html sieht man den Zeilenumbruch. Im Listing sieht es so aus.
<img width="312" height="72" alt="grafik" src="https://github.com/user-attachments/assets/bbfdb235-9e1e-43d1-8a61-863ff7ea7e17" />

---
2. `[BR]`, das als Ersatz für einen Zeilenumbruch bei den `Additional hints` dient, soll auch als Zeilenumbruch über den Parameter `#Hints#` korrekt dargestellt werden.
Beispiel: https://coord.info/GCB4Z15
