### PR TITLE
[General] Prevent user menu from disappearing behind page elements

### DIFF
--- a/data/main.css
+++ b/data/main.css
@@ -65,6 +65,7 @@ gclh_nav .wrapper {
     padding-left: 32px;
     padding-right: 32px;
     width: 100%;
+    z-index: 9000;
 }
 gclh_nav ul {
     list-style: none;

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -1540,7 +1540,7 @@ var mainGC = function() {
     css += create_coloring_css();
     // Special css for searchmap.
     if (is_page('searchmap')) {
-        css += 'gclh_nav .wrapper {z-index: 1006;} gclh_nav li input {height: unset !important;}';
+        css += 'gclh_nav li input {height: unset !important;}';
         css += '.profile-panel .li-user-toggle svg {height: 13px;}';
     }
     appendCssStyle(css);


### PR DESCRIPTION
Close #2992.

This PR prevents the user menu from disappearing behind page elements (on any page).
More details can be found [there](https://github.com/2Abendsegler/GClh/issues/2992#issuecomment-4000215968).