### PR TITLE
[Browse Map] Misaligned search field in header

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -2077,6 +2077,10 @@ var mainGC = function() {
                     appendCssStyle(".menu > li, .Menu > li {height: 100%; padding-top: 2.0em;} .submenu, .SubMenu {margin-top: 2.0em;}");
                 }
             }
+            // On browse map, if Change Header Layout is disabled, ensure that search field is aligned correctly.
+            if (!settings_change_header_layout && is_page("map")) {
+                appendCssStyle(".menu input, .Menu input {margin: 0;}");
+            }
             if (settings_bookmarks_on_top && $('.Menu, .menu').length > 0) {
                 var nav_list = $('.Menu, .menu')[0];
                 var menu = document.createElement("li");


### PR DESCRIPTION
On browse map only, if `Change Header Layout` is disabled, the search field isn't aligned correctly:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/48442bef-cc91-456e-a23f-f2601a934e93" />

Solution is to set `margin: 0` for the search field in that specific case:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/47e810a0-172e-491f-a073-abf16eb6d064" />

