### PR TITLE
[Config] Wrong parameter in config standard file

### DIFF
--- a/data/config_standard.txt
+++ b/data/config_standard.txt
@@ -365,7 +365,7 @@
   "settings_sort_map_layers": false,
   "settings_add_overlay_wmthiking": true,
   "settings_add_overlay_wmtcycling": true,
-  "settings_add_overlay_wmtmtb": true,  
+  "settings_add_overlay_wmtmtb": true,
   "settings_pq_splitter_pqname": "PQ_Splitter_",
   "settings_pq_splitter_how_often": 2,
   "settings_pq_splitter_not_ignored": false,

--- a/data/config_standard.txt
+++ b/data/config_standard.txt
@@ -359,7 +359,7 @@
   "settings_larger_map_as_browse_map": false,
   "settings_fav_proz_cod": true,
   "settings_upgrade_button_header_remove": false,
-  "settings_add_search_in_logs_func true": true,
+  "settings_add_search_in_logs_func": true,
   "settings_unsaved_log_message": true,
   "settings_show_add_cache_info_in_log_page": true,
   "settings_sort_map_layers": false,


### PR DESCRIPTION
`"settings_add_search_in_logs_func true": true,`
anstatt
`"settings_add_search_in_logs_func": true,`