### PR TITLE
[Global] Fix separator in horizontal header layout

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -2139,6 +2139,7 @@ var mainGC = function() {
                         for (var i = 1; i < menuChilds.length; i += 2) {
                             var separator = document.createElement("li");
                             separator.appendChild(document.createTextNode("|"));
+                            if ($(menuChilds[i-1]).hasClass("mobile")) $(separator).addClass("mobile");
                             menuChilds[i].parentNode.insertBefore(separator, menuChilds[i]);
                         }
                     }


### PR DESCRIPTION
In horizontal header layout, if the GS link `Play` is visible, there are two separators instead of one:  
<img width="200" alt="image" src="https://github.com/user-attachments/assets/0fad88b0-11a5-4b44-b56e-020fcd6a0e41" />

One of the separators belongs to the hidden GS link `Account` (only visible on mobiles), but isn't hidden.
