### PR TITLE
[Cache Listing, Maps] Prevent overflows in preformatted text

### DIFF
--- a/data/main.css
+++ b/data/main.css
@@ -685,6 +685,11 @@ table .markdown-output~tr.AlternatingRow td {
     background-color: #e6f7ef;
 }
 
+/* Prevent overflows in preformatted text (HTML pre-tag). */
+pre {
+  white-space: pre-wrap;
+}
+
 /* Config, Sync. */
 .settings_overlay {
     width: 600px;


### PR DESCRIPTION
Prevent overflows in preformatted text for example in latest logs or logs in VIP Lists.

Example: GCAX5TM
Hier tritt der Text in der Search Map bei den Latest Logs aus dem Bereich aus und es wird ein Schiebebalken angezeigt. 
![_01 - Balken in Search Map durch pre mit code](https://github.com/user-attachments/assets/2e74681a-2a34-4e02-9e7d-ae2974478735)

