### PR TITLE
[My Lists] The "more" pop-up is not fully visible due to the header.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -1696,6 +1696,9 @@ var mainGC = function() {
                 tlc('Body found');
                 // Integrate old header.
                 $('body').prepend(header_old);
+                // Reduce z-index for old header on specific pages:
+                // My Lists: It must not be greater than 2000 because of the "more" pop-up.
+                if (is_page('lists')) appendCssStyle('gclh_nav .wrapper {z-index: 2000 !important}');
                 // Run header relevant features.
                 tlc('START setUserParameter');
                 setUserParameter();

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -1698,7 +1698,7 @@ var mainGC = function() {
                 $('body').prepend(header_old);
                 // Reduce z-index for old header on specific pages:
                 // My Lists: It must not be greater than 2000 because of the "more" pop-up.
-                if (is_page('lists')) appendCssStyle('gclh_nav .wrapper {z-index: 2000 !important}');
+                if (is_page('lists')) appendCssStyle('gclh_nav .wrapper {z-index: 2000 !important;}');
                 // Run header relevant features.
                 tlc('START setUserParameter');
                 setUserParameter();


### PR DESCRIPTION
The current z-index for our header is 2500. For Search Map, we need a z-index of at least 2002. For My Lists page, it must not be greater than 2000 because of the "more" pop-up. 

The new z-index for the My Lists page should be set to 2000.

![Screenshot 2026-03-22 140747](https://github.com/user-attachments/assets/722ace1a-309c-40fa-a9c6-36620f0276c1)
