### PR TITLE
[Own Public Profile] Config does not open on about tab

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -14915,44 +14915,50 @@ var mainGC = function() {
         try {
             let url = document.location.href;
             if (url.match(/tab=geocaches/i)) {
-                if (!$('#ctl00_ContentBody_ProfilePanel1_geocachesPrivacyIcon')[0]) return;
-                let link = $('#full-privacy-text a').attr('href');
-                let icon = $('#ctl00_ContentBody_ProfilePanel1_geocachesPrivacyIcon').attr('src');
-                $('#ctl00_ContentBody_ProfilePanel1_geocachesOwnerViewSettings').hide();
-                $('.finds-col-header h3').append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_geocachesPrivacyText').html().trim()} - Change it here"><img src="${icon}" /></a>`);
-                $('.finds-col-header .minorDetails').html('&nbsp;'+$('.finds-col-header .minorDetails').html());
-                $('#ctl00_ContentBody_ProfilePanel1_geocachesHideOwnerViewSettings').hide();
-                $('.hides-col-header h3').append(`&nbsp;<img src="/images/icons/public_icon.svg" title="${$('#ctl00_ContentBody_ProfilePanel1_geocachesHideOwnerViewSettings span').html().trim()}" />`);
-                $('.hides-col-header .minorDetails').html('&nbsp;'+$('.hides-col-header .minorDetails').html());
+                if ($('#ctl00_ContentBody_ProfilePanel1_geocachesPrivacyIcon')[0]) {
+                    let link = $('#full-privacy-text a').attr('href');
+                    let icon = $('#ctl00_ContentBody_ProfilePanel1_geocachesPrivacyIcon').attr('src');
+                    $('#ctl00_ContentBody_ProfilePanel1_geocachesOwnerViewSettings').hide();
+                    $('.finds-col-header h3').append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_geocachesPrivacyText').html().trim()} - Change it here"><img src="${icon}" /></a>`);
+                    $('.finds-col-header .minorDetails').html('&nbsp;' + $('.finds-col-header .minorDetails').html());
+                    $('#ctl00_ContentBody_ProfilePanel1_geocachesHideOwnerViewSettings').hide();
+                    $('.hides-col-header h3').append(`&nbsp;<img src="/images/icons/public_icon.svg" title="${$('#ctl00_ContentBody_ProfilePanel1_geocachesHideOwnerViewSettings span').html().trim()}" />`);
+                    $('.hides-col-header .minorDetails').html('&nbsp;' + $('.hides-col-header .minorDetails').html());
+                }
             } else if (url.match(/tab=trackables/i)) {
-                if (!$('#ctl00_ContentBody_ProfilePanel1_trackablesOwnerViewSettings')[0]) return;
-                let link = $('#ctl00_ContentBody_ProfilePanel1_trackablesOwnerViewSettings a').attr('href');
-                $('#ctl00_ContentBody_ProfilePanel1_trackablesOwnerViewSettings').hide();
-                $('h3').append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_trackablesPrivacyText').html().trim()} - Change it here"><img src="/images/icons/public_icon.svg" /></a>`);
+                if ($('#ctl00_ContentBody_ProfilePanel1_trackablesOwnerViewSettings')[0]) {
+                    let link = $('#ctl00_ContentBody_ProfilePanel1_trackablesOwnerViewSettings a').attr('href');
+                    $('#ctl00_ContentBody_ProfilePanel1_trackablesOwnerViewSettings').hide();
+                    $('h3').append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_trackablesPrivacyText').html().trim()} - Change it here"><img src="/images/icons/public_icon.svg" /></a>`);
+                }
             } else if (url.match(/tab=souvenirs/i)) {
-                if (!$('#ctl00_ContentBody_ProfilePanel1_souvenirsPrivacyIcon')[0]) return;
-                let link = $('#ctl00_ContentBody_ProfilePanel1_souvenirsOwnerViewSettings a').attr('href');
-                let icon = $('#ctl00_ContentBody_ProfilePanel1_souvenirsPrivacyIcon').attr('src');
-                $('#ctl00_ContentBody_ProfilePanel1_souvenirsOwnerViewSettings').hide();
-                $('h3').append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_souvenirsPrivacyText').html().trim()} - Change it here"><img src="${icon}" /></a>`);
+                if ($('#ctl00_ContentBody_ProfilePanel1_souvenirsPrivacyIcon')[0]) {
+                    let link = $('#ctl00_ContentBody_ProfilePanel1_souvenirsOwnerViewSettings a').attr('href');
+                    let icon = $('#ctl00_ContentBody_ProfilePanel1_souvenirsPrivacyIcon').attr('src');
+                    $('#ctl00_ContentBody_ProfilePanel1_souvenirsOwnerViewSettings').hide();
+                    $('h3').append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_souvenirsPrivacyText').html().trim()} - Change it here"><img src="${icon}" /></a>`);
+                }
             } else if (url.match(/tab=gallery/i)) {
-                if (!$('#ctl00_ContentBody_ProfilePanel1_galleryPrivacyIcon')[0]) return;
-                let link = $('#ctl00_ContentBody_ProfilePanel1_galleryOwnerViewSettings a').attr('href');
-                let icon = $('#ctl00_ContentBody_ProfilePanel1_galleryPrivacyIcon').attr('src');
-                $('#ctl00_ContentBody_ProfilePanel1_galleryOwnerViewSettings').hide();
-                $('h3').append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_galleryPrivacyText').html().trim()} - Change it here"><img src="${icon}" /></a>`);
+                if ($('#ctl00_ContentBody_ProfilePanel1_galleryPrivacyIcon')[0]) {
+                    let link = $('#ctl00_ContentBody_ProfilePanel1_galleryOwnerViewSettings a').attr('href');
+                    let icon = $('#ctl00_ContentBody_ProfilePanel1_galleryPrivacyIcon').attr('src');
+                    $('#ctl00_ContentBody_ProfilePanel1_galleryOwnerViewSettings').hide();
+                    $('h3').append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_galleryPrivacyText').html().trim()} - Change it here"><img src="${icon}" /></a>`);
+                }
             } else if (url.match(/tab=stats/i)) {
-                if (!$('#ctl00_ContentBody_ProfilePanel1_statisticsPrivacyIcon')[0]) return;
-                let link = $('#ctl00_ContentBody_ProfilePanel1_statisticsOwnerViewSettings a').attr('href');
-                let icon = $('#ctl00_ContentBody_ProfilePanel1_statisticsPrivacyIcon').attr('src');
-                $('#ctl00_ContentBody_ProfilePanel1_statisticsOwnerViewSettings').hide();
-                $('h3').first().append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_statisticsPrivacyText').html().trim()} - Change it here"><img src="${icon}" /></a>`);
+                if ($('#ctl00_ContentBody_ProfilePanel1_statisticsPrivacyIcon')[0]) {
+                    let link = $('#ctl00_ContentBody_ProfilePanel1_statisticsOwnerViewSettings a').attr('href');
+                    let icon = $('#ctl00_ContentBody_ProfilePanel1_statisticsPrivacyIcon').attr('src');
+                    $('#ctl00_ContentBody_ProfilePanel1_statisticsOwnerViewSettings').hide();
+                    $('h3').first().append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_statisticsPrivacyText').html().trim()} - Change it here"><img src="${icon}" /></a>`);
+                }
             } else if (!url.match(/tab=lists/i)) { // Profilinformationen
-                if (!$('#ctl00_ContentBody_ProfilePanel1_profilePrivacyIcon')[0]) return;
-                let link = $('#ctl00_ContentBody_ProfilePanel1_profileOwnerViewSettings a').attr('href');
-                let icon = $('#ctl00_ContentBody_ProfilePanel1_profilePrivacyIcon').attr('src');
-                $('#ctl00_ContentBody_ProfilePanel1_profileOwnerViewSettings').hide();
-                $('h3').append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_profilePrivacyText').html().trim()} - Change it here"><img src="${icon}" /></a>`);
+                if ($('#ctl00_ContentBody_ProfilePanel1_profilePrivacyIcon')[0]) {
+                    let link = $('#ctl00_ContentBody_ProfilePanel1_profileOwnerViewSettings a').attr('href');
+                    let icon = $('#ctl00_ContentBody_ProfilePanel1_profilePrivacyIcon').attr('src');
+                    $('#ctl00_ContentBody_ProfilePanel1_profileOwnerViewSettings').hide();
+                    $('h3').append(`&nbsp;<a href="${link}" class="gclh_privacy" title="${$('#ctl00_ContentBody_ProfilePanel1_profilePrivacyText').html().trim()} - Change it here"><img src="${icon}" /></a>`);
+                }
             }
             let css = 'h3 {display:flex;}';
             css += '.gclh_privacy {display: inline-flex;}';


### PR DESCRIPTION
If you open your own private profile and try to open the gclh config, the following error occurs:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/df5d171e-b298-474a-b696-1adee9e99bce" />

To reproduce:
1. open [https://www.geocaching.com/p/](https://www.geocaching.com/p/)
2. stay on `About` tab
3. open gclh config
4. error occurs

The error is kind of special and only occurs if you did't add any content to the About section in your GS Profile Information settings (then the PrivacyIcon is missing):
<img width="400" alt="image" src="https://github.com/user-attachments/assets/6ad52552-d495-4243-a3be-5c5663950587" />

Reason for this issue is a sleeping bug (> 3 years) in `Show smaller privacy buttons`:  
`if (!$('#ctl00_ContentBody_ProfilePanel1_profilePrivacyIcon')[0]) return;`

The return statement, if hit, exits the function `mainGC()` and therefore some variables are missing for running the config.

The other five `if` statements above also have a return statement and would run into the same problem, if the corresponding PrivacyIcon is not available.  
Consequently they are also fixed.

