### PR TITLE
[Global] Header menue

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -2122,7 +2122,7 @@ var mainGC = function() {
                     code += "  else document.location.href = '/seek/nearest.aspx?navi_search='+search;";
                     code += "}";
                     injectPageScript(code, "body");
-                      var searchfield = "<li><input onKeyDown='if (event.keyCode==13 && event.altKey == false && event.shiftKey == false) {gclh_search_logs(!!event.ctrlKey); return false;}' type='text' size='" + (browser == 'firefox' ? "9":"7") + "' name='navi_search' id='navi_search' style='margin: 0px; padding: 1px; font-weight: bold; font-family: sans-serif; border-radius: 7px 7px 7px 7px; width: auto; height: 23px !important;' value='" + settings_bookmarks_search_default + "'></li>";
+                    var searchfield = "<li><input onKeyDown='if (event.keyCode==13 && event.altKey == false && event.shiftKey == false) {gclh_search_logs(!!event.ctrlKey); return false;}' type='text' size='" + (browser == 'firefox' ? "9":"7") + "' name='navi_search' id='navi_search' style='margin: 0px; padding: 1px; font-weight: bold; font-family: sans-serif; border-radius: 7px 7px 7px 7px; width: auto; height: 23px !important;' value='" + settings_bookmarks_search_default + "'></li>";
                     $(".Menu, .menu").append(searchfield);
                 }
 

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -1773,10 +1773,15 @@ var mainGC = function() {
                 // Alle Seiten: Grundeinstellungen:
                 // ----------
                 var css = "";
-                // Alignment of menu content (links and menus); a:height ensures that the submenus remain open when hovering over with the mouse.
+                // Alignment of menu content (links and menus).
                 css += "gclh_nav ul.menu {display: flex;}";
-                css += "gclh_nav ul.menu>li>a {height: 60px; display: flex !important; align-items: center;}";
+                css += "gclh_nav ul.menu>li>a {display: flex !important; align-items: center;}";
                 css += ".menu>li {height: unset;}";
+                // Bei vertikalem Menü und bei einzeiligem horizontalem Menü, sicherstellen, dass die Untermenüs der vertikalen Menüelemente beim
+                // Drüberfahren mit der Maus geöffnet bleiben.
+                if (settings_bookmarks_top_menu || (!settings_bookmarks_top_menu && settings_menu_number_of_lines == 1)) {
+                    css += "ul.menu > li {margin-top: 18px !important;} gclh_nav ul.menu > li > a, #navi_search, .menu_separator {margin-bottom: 18px !important;}";
+                }
                 // Font-Size für Menüs, Font-Size für Untermenüs in Pixel.
                 var font_size_menu = parseInt(settings_font_size_menu);
                 if ((font_size_menu == 0) || (font_size_menu < 0) || (font_size_menu > 16)) font_size_menu = 16;
@@ -1822,6 +1827,8 @@ var mainGC = function() {
                     ".#m li a:hover, .#m li a:focus {color: #FFFFFF !important; outline: unset !important;}" +
                     // Schriftfarbe Search Field.
                     "#navi_search {color: #4a4a4a;} #navi_search:focus, #navi_search:focus-visible, #navi_search:active {outline: none; box-shadow: none;}" +
+                    // Separator.
+                    ".menu_separator {padding-bottom: 2px !important;}" +
                     // Submenü im Vordergrund.
                     ".#m .#sm {z-index: 1001;}" +
                     // Schriftfarbe Untermenü.
@@ -1853,7 +1860,7 @@ var mainGC = function() {
                     css += "ul.#m {line-height: 16px !important;}";
                     // Zeilenabstand in Abhängigkeit von Anzahl Zeilen.
                     if      (settings_menu_number_of_lines == 2) css += "ul.#m li a {padding-top: 4px !important; padding-bottom: 4px !important;}";
-                    else if (settings_menu_number_of_lines == 3) css += "ul.#m li a {padding-top: 1px !important; padding-bottom: 1px !important;}";
+                    else if (settings_menu_number_of_lines == 3) css += "ul.#m li a {padding-top: 3px !important; padding-bottom: 3px !important;}";
                 }
                 // Message Center Icon entfernen.
                 if (settings_remove_message_in_header) $('.messagecenterheaderwidget').remove();
@@ -1889,8 +1896,8 @@ var mainGC = function() {
                     } else {
                         css += ".#m ul.#sm {margin-top: -2px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
                         if      (settings_menu_number_of_lines == 1) css += "ul.#m {top:   0px !important; position: inherit;}";
-                        else if (settings_menu_number_of_lines == 2) css += "ul.#m {top:  -8px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important} .#m .submenu::after {top: 5px} .#m ul.#sm {margin-top: -4px;";
-                        else if (settings_menu_number_of_lines == 3) css += "ul.#m {top: -13px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important} .#m .submenu::after {top: 5px}";
+                        else if (settings_menu_number_of_lines == 2) css += "ul.#m {top:  -8px !important; position: inherit; flex-wrap: wrap;} .#m .submenu::after {top: 5px}";
+                        else if (settings_menu_number_of_lines == 3) css += "ul.#m {top: -18px !important; position: inherit; flex-wrap: wrap;} .#m .submenu::after {top: 5px}";
                     }
                     // Prevent the user area in the header from moving to the left on narrow screens.
                     css += "ul.menu {order: unset;} #ctl00_uxLoginStatus_divSignedIn {height: auto;} .messagecenterheaderwidget.li-messages {position: static;}";
@@ -1917,8 +1924,8 @@ var mainGC = function() {
                     } else {
                         css += ".#m ul.#sm {margin-top: -2px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
                         if      (settings_menu_number_of_lines == 1) css += "ul.#m {top:   0px !important; position: inherit;}";
-                        else if (settings_menu_number_of_lines == 2) css += "ul.#m {top:  -8px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important} .#m .submenu::after {top: 5px} .#m ul.#sm {margin-top: -4px;";
-                        else if (settings_menu_number_of_lines == 3) css += "ul.#m {top: -13px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important} .#m .submenu::after {top: 5px}";
+                        else if (settings_menu_number_of_lines == 2) css += "ul.#m {top:  -8px !important; position: inherit; flex-wrap: wrap;} .#m .submenu::after {top: 5px}";
+                        else if (settings_menu_number_of_lines == 3) css += "ul.#m {top: -18px !important; position: inherit; flex-wrap: wrap;} .#m .submenu::after {top: 5px}";
                     }
                 }
                 // Alle Seiten: Platzhalter umsetzen:
@@ -2064,10 +2071,6 @@ var mainGC = function() {
                     appendCssStyle(".menu > li, .Menu > li {height: 100%; padding-top: 2.0em;} .submenu, .SubMenu {margin-top: 2.0em;}");
                 }
             }
-            // On browse map, if Change Header Layout is disabled, ensure that search field is aligned correctly.
-            if (!settings_change_header_layout && is_page("map")) {
-                appendCssStyle(".menu input, .Menu input {margin: 0;}");
-            }
             if (settings_bookmarks_on_top && $('.Menu, .menu').length > 0) {
                 var nav_list = $('.Menu, .menu')[0];
                 var menu = document.createElement("li");
@@ -2122,7 +2125,7 @@ var mainGC = function() {
                     code += "  else document.location.href = '/seek/nearest.aspx?navi_search='+search;";
                     code += "}";
                     injectPageScript(code, "body");
-                    var searchfield = "<li><input onKeyDown='if (event.keyCode==13 && event.altKey == false && event.shiftKey == false) {gclh_search_logs(!!event.ctrlKey); return false;}' type='text' size='" + (browser == 'firefox' ? "9":"7") + "' name='navi_search' id='navi_search' style='margin: 0px; padding: 1px; font-weight: bold; font-family: sans-serif; border-radius: 7px 7px 7px 7px; width: auto; height: 23px !important;' value='" + settings_bookmarks_search_default + "'></li>";
+                    var searchfield = "<li><input onKeyDown='if (event.keyCode==13 && event.altKey == false && event.shiftKey == false) {gclh_search_logs(!!event.ctrlKey); return false;}' type='text' size='" + (browser == 'firefox' ? "9":"7") + "' name='navi_search' id='navi_search' style='" + (settings_change_header_layout ? 'margin: 1px 0px 0px 0px;' : 'margin: 0px;') + " padding: 1px; font-weight: bold; font-family: sans-serif; border-radius: 7px 7px 7px 7px; width: auto; height: 24px !important;' value='" + settings_bookmarks_search_default + "'></li>";
                     $(".Menu, .menu").append(searchfield);
                 }
 
@@ -2134,6 +2137,7 @@ var mainGC = function() {
                             var separator = document.createElement("li");
                             separator.appendChild(document.createTextNode("|"));
                             if ($(menuChilds[i-1]).hasClass("mobile")) $(separator).addClass("mobile");
+                            $(separator).addClass("menu_separator");
                             menuChilds[i].parentNode.insertBefore(separator, menuChilds[i]);
                         }
                     }

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -1773,6 +1773,10 @@ var mainGC = function() {
                 // Alle Seiten: Grundeinstellungen:
                 // ----------
                 var css = "";
+                // Alignment of menu content (links and menus); a:height ensures that the submenus remain open when hovering over with the mouse.
+                css += "gclh_nav ul.menu {display: flex;}";
+                css += "gclh_nav ul.menu>li>a {height: 60px; display: flex !important; align-items: center;}";
+                css += ".menu>li {height: unset;}";
                 // Font-Size für Menüs, Font-Size für Untermenüs in Pixel.
                 var font_size_menu = parseInt(settings_font_size_menu);
                 if ((font_size_menu == 0) || (font_size_menu < 0) || (font_size_menu > 16)) font_size_menu = 16;
@@ -1841,10 +1845,8 @@ var mainGC = function() {
                     ".#m .#sm {margin-left: 0 !important}";
                 // Vertikales Menü ausrichten.
                 if (settings_bookmarks_top_menu) {
-                    // Menüzeilenhöhe, Menü nicht flex.
+                    // Menüzeilenhöhe.
                     css += "ul.#m {line-height: 16px; display: block;}";
-                    // Zwischen Menüname und Submenü keine Lücke lassen, sonst klappts nicht mit einfachem Aufklappen.
-                    css += ".#m li a, .#m li a:link, .#m li a:visited {margin-bottom: 13px;} .#m ul.#sm {margin-top: -6px;}";
                 // Horizontales Menü ausrichten.
                 } else {
                     // Menüzeilenhöhe.
@@ -1852,11 +1854,6 @@ var mainGC = function() {
                     // Zeilenabstand in Abhängigkeit von Anzahl Zeilen.
                     if      (settings_menu_number_of_lines == 2) css += "ul.#m li a {padding-top: 4px !important; padding-bottom: 4px !important;}";
                     else if (settings_menu_number_of_lines == 3) css += "ul.#m li a {padding-top: 1px !important; padding-bottom: 1px !important;}";
-                    css += "gclh_nav ul.menu {display: flex;}";
-                    css += "gclh_nav ul.menu>li>a {height: 60px; display: flex !important; align-items: center;}";
-                    css += ".menu>li {height: unset;}";
-                    css += "#l {flex: none !important; flex-basis: 32px;}";
-                    css += "#navi_search {margin: 0px !important}";
                 }
                 // Message Center Icon entfernen.
                 if (settings_remove_message_in_header) $('.messagecenterheaderwidget').remove();
@@ -1866,7 +1863,7 @@ var mainGC = function() {
                     changeGcLogo(side);
                 }
                 css +=
-                    "#l {flex: unset; overflow: unset; margin-left: -32px} #newgclogo {width: 30px !important;}" +
+                    "#l {flex: none; flex-basis: 32px; overflow: unset; margin-left: -32px} #newgclogo {width: 30px !important;}" +
                     ".#m {width: " + new_width_menu + "px !important; margin-left: 6px !important;}" +
                     "nav .wrapper, gclh_nav .wrapper {min-width: " + (new_width + 40) + "px !important; max-width: unset;}";
                 // Bereich links ausrichten in Abhängigkeit davon, ob Logo geändert wird und ob GC Tour im Einsatz ist.
@@ -1881,26 +1878,19 @@ var mainGC = function() {
                     css += "nav .wrapper {padding-right: " + new_padding_right + "px !important; width: unset;}";
                     // Vertikales Menü ausrichten.
                     if (settings_bookmarks_top_menu) {
-                        if (is_page("find_cache") || (is_page("settings") && document.location.pathname.match(/^\/live\//))) {
-                            css += ".#m li:not(.attention-link-parent) ul.#sm {margin-top: 17px;}";
-                        }
-                        css += ".#m ul.#sm {margin-top: 0px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
-                        // Menü, Searchfield ausrichten in Abhängigkeit von Schriftgröße. Menü nicht flex.
+                        css += ".#m ul.#sm {margin-top: -2px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
+                        // Menü, Searchfield ausrichten.
                         if (settings_menu_float_right) {
-                            css += "ul.#m > li {margin-top: " + (3 + (16 - font_size_menu) / 2) + "px;}";
+                            css += "gclh_nav ul.menu {justify-content: flex-end;}";
                         } else {
-                            if (is_page("map")) css += "ul.#m > li {margin-top: " + (3 + (16 - font_size_menu) / 2) + "px;}";
-                            else css += "ul.#m > li {margin-top: " + (4 + (16 - font_size_menu) / 2) + "px;}";
+                            css += "gclh_nav ul.menu {justify-content: flex-start;}";
                         }
-                        // Menü in Karte ausrichten.
-                        if (is_page("map") && !settings_menu_float_right) css += ".#m {height: unset !important;}";
-                        if (is_page("map") && settings_menu_float_right) css += "#navi_search {margin: 0 !important;}";
                     // Horizontales Menü ausrichten in Abhängigkeit von Anzahl Zeilen.
                     } else {
-                        css += ".#m ul.#sm {margin-top: 0px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
+                        css += ".#m ul.#sm {margin-top: -2px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
                         if      (settings_menu_number_of_lines == 1) css += "ul.#m {top:   0px !important; position: inherit;}";
-                        else if (settings_menu_number_of_lines == 2) css += "ul.#m {top:  -8px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important}";
-                        else if (settings_menu_number_of_lines == 3) css += "ul.#m {top: -13px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important}";
+                        else if (settings_menu_number_of_lines == 2) css += "ul.#m {top:  -8px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important} .#m .submenu::after {top: 5px} .#m ul.#sm {margin-top: -4px;";
+                        else if (settings_menu_number_of_lines == 3) css += "ul.#m {top: -13px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important} .#m .submenu::after {top: 5px}";
                     }
                     // Prevent the user area in the header from moving to the left on narrow screens.
                     css += "ul.menu {order: unset;} #ctl00_uxLoginStatus_divSignedIn {height: auto;} .messagecenterheaderwidget.li-messages {position: static;}";
@@ -1916,25 +1906,19 @@ var mainGC = function() {
                     }
                     // Vertikales Menü  ausrichten.
                     if (settings_bookmarks_top_menu) {
-                        if (is_page("cache_listing") && $('.ul__cache-details.unstyled')[0]) {
-                            css += ".#m ul.#sm {margin-top: -10px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
-                        } else {
-                            css += ".#m ul.#sm {margin-top: 17px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
-                        }
-                        // Zwischen Menüname und Submenü keine Lücke lassen, sonst klappt das nicht mit dem einfachen Aufklappen.
-                        css += ".#m > li .dropdown {padding-bottom: 14px !important;}";
-                        // Menü, Searchfield ausrichten in Abhängigkeit von Schriftgröße. Menü nicht flex.
+                        css += ".#m ul.#sm {margin-top: -2px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
+                        // Menü, Searchfield ausrichten.
                         if (settings_menu_float_right) {
-                            css += "ul.#m > li {margin-top: " + (7 + (16 - font_size_menu) / 2) + "px;}";
+                            css += "gclh_nav ul.menu {justify-content: flex-end;}";
                         } else {
-                            css += "ul.#m > li {margin-top: " + (5 + (16 - font_size_menu) / 2) + "px;}";
+                            css += "gclh_nav ul.menu {justify-content: flex-start;}";
                         }
                     // Horizontales Menü ausrichten in Abhängigkeit von Anzahl Zeilen.
                     } else {
-                        css += ".#m ul.#sm {margin-top: 0px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
+                        css += ".#m ul.#sm {margin-top: -2px; margin-left: 32px !important;} .#m .submenu::after {left: 4px; width: 26px;}";
                         if      (settings_menu_number_of_lines == 1) css += "ul.#m {top:   0px !important; position: inherit;}";
-                        else if (settings_menu_number_of_lines == 2) css += "ul.#m {top:  -8px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important}";
-                        else if (settings_menu_number_of_lines == 3) css += "ul.#m {top: -13px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important}";
+                        else if (settings_menu_number_of_lines == 2) css += "ul.#m {top:  -8px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important} .#m .submenu::after {top: 5px} .#m ul.#sm {margin-top: -4px;";
+                        else if (settings_menu_number_of_lines == 3) css += "ul.#m {top: -13px !important; position: inherit; flex-wrap: wrap;} gclh_nav ul.menu>li>a {height: auto !important} .#m .submenu::after {top: 5px}";
                     }
                 }
                 // Alle Seiten: Platzhalter umsetzen:
@@ -2138,7 +2122,7 @@ var mainGC = function() {
                     code += "  else document.location.href = '/seek/nearest.aspx?navi_search='+search;";
                     code += "}";
                     injectPageScript(code, "body");
-                    var searchfield = "<li><input onKeyDown='if (event.keyCode==13 && event.altKey == false && event.shiftKey == false) {gclh_search_logs(!!event.ctrlKey); return false;}' type='text' size='" + (browser == 'firefox' ? "9":"7") + "' name='navi_search' id='navi_search' style='margin-bottom: -1px; padding: 1px; font-weight: bold; font-family: sans-serif; border-radius: 7px 7px 7px 7px; width: auto;' value='" + settings_bookmarks_search_default + "'></li>";
+                      var searchfield = "<li><input onKeyDown='if (event.keyCode==13 && event.altKey == false && event.shiftKey == false) {gclh_search_logs(!!event.ctrlKey); return false;}' type='text' size='" + (browser == 'firefox' ? "9":"7") + "' name='navi_search' id='navi_search' style='margin: 0px; padding: 1px; font-weight: bold; font-family: sans-serif; border-radius: 7px 7px 7px 7px; width: auto; height: 23px !important;' value='" + settings_bookmarks_search_default + "'></li>";
                     $(".Menu, .menu").append(searchfield);
                 }
 
@@ -2151,18 +2135,6 @@ var mainGC = function() {
                             separator.appendChild(document.createTextNode("|"));
                             if ($(menuChilds[i-1]).hasClass("mobile")) $(separator).addClass("mobile");
                             menuChilds[i].parentNode.insertBefore(separator, menuChilds[i]);
-                        }
-                    }
-                }
-                // Vertikale Menüs rechts ausrichten.
-                if (settings_bookmarks_top_menu && settings_menu_float_right && settings_change_header_layout) {
-                    if ($('ul.Menu, ul.menu')[0]) {
-                        var menu = $('ul.Menu, ul.menu')[0];
-                        var menuChilds = $('ul.Menu, ul.menu')[0].children;
-                        for (var i = 0; i < menuChilds.length; i++) {
-                            var child = menu.removeChild(menu.children[menuChilds.length-1-i]);
-                            child.setAttribute("style", "float: right;");
-                            menu.appendChild(child);
                         }
                     }
                 }


### PR DESCRIPTION
Related to #3009, #3010, #3013, #3020, #3027, #3037 und #3038.

Hier enthalten ist insbesondere die Überarbeitung des gesamten Menüs aus #3010 von DieBatzen.  

Weitere Anpassungen:
- Aufklappen der Untermenüs bei den vertikalen Menüs verbessert.
- Zeilenabstand im horizontalen Menü für 2-zeilige und 3-zeilige Darstellung verbessert. 
- Ausrichtung Separator verbessert.

---
Beispiele für horizontale Menüs:

![Menü horizontale 1-zeilig](https://github.com/user-attachments/assets/649a25df-2a70-497c-82c8-5894555c7385)

![Menü horizontale 2-zeilig](https://github.com/user-attachments/assets/e0bb5d06-31a4-4cd8-a969-b417b78c915b)

![Menü horizontale 3-zeilig](https://github.com/user-attachments/assets/1bec18ba-9e85-4e67-b3de-c8745d622a4f)
