### PR TITLE
[Browse Map] Prevent tooltip with cache name if cache detail pop-up is available

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -12724,6 +12724,8 @@ var mainGC = function() {
             css += '.leaflet-control-scale-line:first-child {box-shadow: 0 -1px 5px rgba(0, 0, 0, 0.2) !important;}';
             // Improve clickability on list names of add to list pop up.
             css += '.add-list li button {width: 100%; text-align: left;} .pop-modal .status {width: initial;}';
+            // Prevent tooltip with cache name if cache detail pop-up is available.
+            css += '.leaflet-container:has(.leaflet-popup) .map-tooltip {display: none !important;}';
             appendCssStyle(css);
         } catch(e) {gclh_error("Improve Browse Map",e);}
     }


### PR DESCRIPTION
Prevent tooltip with cache name if cache detail pop-up is available. This prevents tooltips with cache names from caches located below the cache detail pop-up from overlapping the cache detail pop-up.
(It would be even better if this only took place in the pop-up area, but I haven't managed to do that.)

![1](https://github.com/user-attachments/assets/58c37f6b-db54-45ab-b562-d7b979e808b3)
