### PR TITLE
[Browse Map] The user menu does not disappear with a second click.

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -1728,6 +1728,13 @@ var mainGC = function() {
                 tlc('START User profile');
                 $('#ctl00_uxLoginStatus_divSignedIn button.li-user-toggle')[0].addEventListener('click', function(){
                     $('#ctl00_uxLoginStatus_divSignedIn li.li-user:not(#pgc_gclh)').toggleClass('gclh_open');
+                    // At least on the Browse Map, the class 'user-expanded' is additionally set, but not removed, therefore the menu remains
+                    // when you click on it a second time.
+                    if (!$('#ctl00_uxLoginStatus_divSignedIn li.li-user:not(#pgc_gclh)').hasClass('gclh_open')) {
+                        setTimeout(function(){
+                            $('#ctl00_uxLoginStatus_divSignedIn li.li-user:not(#pgc_gclh) ul.submenu').removeClass('user-expanded');
+                        }, 0);
+                    }
                 });
                 // Disable user profile menu by clicking anywhere else.
                 $(document).click(function(){


### PR DESCRIPTION
At least on the Browse Map, the class 'user-expanded' is additionally set, but not removed, therefore the menu remains when you click on it a second time.