### PR TITLE
[Global] User in header is not available

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -16330,6 +16330,8 @@ var mainGC = function() {
     }
 
 // Do migration tasks for new version.
+// Die Variablen dürfen nicht initialisiert werden, damit der gewünschte Effekt sofort eintritt, weil dabei auch die user parameter wie beispielsweise
+// global_me zurückgesetzt werden. Ein Aufruf von "variablesInit(window)" darf also nicht mehr erfolgen.
     function migrationTasks() {
         // Delete older parameter set_switch_db... (zu v0.17.13).
         if (getValue("migration_task_09", false) != true) {
@@ -16363,8 +16365,6 @@ var mainGC = function() {
             delete CONFIG['settings_but_search_map_new_tab'];
             CONFIG['migration_task_10'] = true;
             GM_setValue("CONFIG", JSON.stringify(CONFIG));
-            // The migrated parameters must be initialized to take effect immediately.
-            variablesInit(window);
         }
         // Delete parameter show_box_dashboard_... (zu v0.18.3).
         if (getValue("migration_task_11", false) != true) {
@@ -16377,7 +16377,6 @@ var mainGC = function() {
             CONFIG = config_tmp;
             GM_setValue("CONFIG", JSON.stringify(CONFIG));
             setValue("migration_task_11", true);
-            variablesInit(window);
         }
     }
 


### PR DESCRIPTION
The user in header is false.
<img width="483" height="108" alt="grafik" src="https://github.com/user-attachments/assets/9a081b01-4c52-492f-a517-a24f80f5ccd6" />

When migrating parameters in `migration_task`, the variables must not be initialized to ensure the desired effect occurs immediately, as this would also reset user parameters such as `global_me`. Therefore, a call to `variablesInit(window)` should no longer be made.

Close #3098