### PR TITLE
[Dashboard] Repair left column after latest website release

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -9512,7 +9512,7 @@ var mainGC = function() {
         try {
             // Specification of anchors for own coding and styles:
             // - Linke Sidebar.
-            var leftSidebar = '#sidebar-left-root';
+            var leftSidebar = '#leftCol';
             // - First Block - Profile Summary.
             var sectionProfile = ' section:has(a[href*="account/settings/profile"])';
 //->xxxx


### PR DESCRIPTION
Repair all features in the left column of the dashboard after the latest website release. 

<img width="356" height="1296" alt="Screen01" src="https://github.com/user-attachments/assets/3df12267-c061-43c6-8f51-3ee73bd7b09a" />
