### PR TITLE
[Dashboard] Repair feature to hide right column after latest website release

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -9854,9 +9854,9 @@ var mainGC = function() {
             // Hide right sidebar.
             function hideRightSidebarDB() {
                 try {
-                    if ($('div.sidebar-right')[0] && !$('#gclh_right_sidebar_wrapper')[0]) {
+                    if ($(rightSidebar)[0] && !$('#gclh_right_sidebar_wrapper')[0]) {
                         const $layoutFeed = $('#LayoutFeed');
-                        const $sidebar_right = $('div.sidebar-right');
+                        const $sidebar_right = $(rightSidebar);
                         const $sidebar_right_max_width = $sidebar_right.css('max-width');
                         $sidebar_right.css('width', $sidebar_right_max_width);
                         const $wrapper = $('<div>', {


### PR DESCRIPTION
Repair feature to hide the right column of the dashboard after the latest website release. 

<img width="425" height="82" alt="Screen03" src="https://github.com/user-attachments/assets/1c7f7522-a815-42e8-a6af-2b279e0f9a1d" />
