### PR TITLE
[Global] Prevent header elements from disappearing behind page elements and vice versa

### DIFF
--- a/data/main.css
+++ b/data/main.css
@@ -71,7 +71,6 @@ gclh_nav .wrapper {
     padding-left: 32px;
     padding-right: 32px;
     width: 100%;
-    z-index: 2500;
 }
 gclh_nav ul {
     list-style: none;

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -1706,9 +1706,9 @@ var mainGC = function() {
                 tlc('Body found');
                 // Integrate old header.
                 $('body').prepend(header_old);
-                // Reduce z-index for old header on specific pages:
-                // My Lists: It must not be greater than 2000 because of the "more" pop-up.
-                if (is_page('lists')) appendCssStyle('gclh_nav .wrapper {z-index: 2000 !important;}');
+                // Set z-index for old header on specific pages to prevent header elements from disappearing behind page elements:
+                // Search Map and Treasures: Prevent menus from disappearing behind icons (with v0.18.5).
+                if (is_page('searchmap') || document.location.href.match(/\.com\/play\/treasure/)) appendCssStyle('gclh_nav .wrapper {z-index: 2500;}');
                 // Run header relevant features.
                 tlc('START setUserParameter');
                 setUserParameter();


### PR DESCRIPTION
Mit #2992 (#3003, #3019, #3048 und es gab auch noch mindestens einen PR davor) haben wir für den Header einen z-index gesetzt. Seitdem macht das immer wieder Probleme und wir mussten schon mehrfach nachbessern und auch Ausnahmen definieren. Für die Cache Gallery, das Profile mit der Gallery und das Profile mit dem Avatar wären nun weitere Ausnahmen notwendig, weil auch hier die Hover Bilder und auch die Bilder hinter dem Header verschwinden können. Die Absicht war eigentlich keine Ausnahmen machen zu müssen, die wir vor den Anpassungen in der Art gemacht hatten, dass wir nur für bestimmte Seiten einen z-index gesetzt hatten, damals Search Map.

Es scheint nun aber doch zielführender zu sein, Ausnahmen wieder in der Art zu machen, dass nur für bestimmte Seiten ein z-index gesetzt wird. Das wird mit diesem PR umgesetzt.

Im Moment sind dafür die Seiten Search Map und Treasures bekannt, die mit einem z-index von 2500 funktionieren.
