### PR TITLE
[Cache Owner Dashboard] Align VIP, VUP, Mail icons and cache count

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -10533,13 +10533,14 @@ var mainGC = function() {
                     $(user).after('<span class="gclh_name"></span>');
                     var target = $(user).closest('.finder-data').find('.gclh_name')[0];
                     $(user).appendTo(target);
+                    $(user).after('<span style="display: block;"></span>');
                     var item = $(user).closest('.activity-item');
                     var GCTBName = $(item).find('h3 a').html().trim();
                     var GCTBCode = $(item).find('.log-meta li')[0].childNodes[1].data;
                     global_name = GCTBName;
                     global_code = '('+GCTBCode+')';
                     global_link = '(https://coord.info/'+GCTBCode+')';
-                    gclh_build_vipvupmail(target, user.innerHTML);
+                    gclh_build_vipvupmail($(target).find('span')[0], user.innerHTML);
                 }
             }
 
@@ -10657,7 +10658,6 @@ var mainGC = function() {
             css += '.username a:hover {color:#02874d; text-decoration:underline;}';
             // Build VIP, Mail, Message icons.
             if (settings_show_vip_list) {
-                css += '.gclh_name a {margin-right: 5px;}';
                 css += '.log-item .gclh_name {margin-left: 5px; margin-top: -3px; padding-bottom: 2px; line-height: 1;}';
                 css += '.log-item .finder-username, .log-item .finder-type, .log-item .finder-find-count {line-height: 1.3 !important;}';
                 css += '.log-item .finder-username {display: block !important;}';
@@ -10665,7 +10665,7 @@ var mainGC = function() {
             }
             // Compact Layout
             if (settings_compact_layout_cod) {
-                css += '.owned-geocache-type-count, h1.page-header {margin: 0 !important}';
+                css += '.owned-geocache-count, .owned-geocache-type-count, h1.page-header {margin: 0 !important}';
                 css += '.widget {z-index: 1;}';
                 css += '.widget .widget-title a, .widget ul a, .widget > span {padding: 5px 10px !important;}';
                 css += '.widget ul {padding: 0 !important;}';


### PR DESCRIPTION
Align VIP, VUP, Mail icons:

before:
<img width="201" height="88" alt="1" src="https://github.com/user-attachments/assets/68acc02e-d443-47aa-8e71-a1b800db00da" />

after:
<img width="206" height="91" alt="2" src="https://github.com/user-attachments/assets/985c8a7f-2dfc-419f-9350-57eace231c40" />

---
Align cache count:

before:
<img width="406" height="85" alt="3" src="https://github.com/user-attachments/assets/ea0af2c5-f081-422c-b78f-76925b3970b5" />

after:
<img width="409" height="87" alt="4" src="https://github.com/user-attachments/assets/2c5627d8-d326-4343-ac6d-bf701e1b5d1b" />

