### PR TITLE
[Search Map] Improve color scheme when hovering the "Display Options for Search Results" button

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -11560,6 +11560,12 @@ var mainGC = function() {
 
                     // Styling.
                     const css = `
+                    .gclh_display_options_control:hover {
+                        background-color: rgb(230, 250, 235) !important;
+                    }
+                    .gclh_display_options_control:hover > svg {
+                        color: rgb(0, 178, 101) !important;
+                    }
                     .gclh_display_options_control > svg {
                         height: 1.9em !important;
                     }


### PR DESCRIPTION
Improve the color scheme when hovering over the "Display Options for Search Results" button on Search Map, just like the other buttons.

No buttons inside checked:
<img width="80" src="https://github.com/user-attachments/assets/f061ee79-dcae-4072-8aba-dbced77015a1" /> <img width="80" src="https://github.com/user-attachments/assets/53370035-e41a-4292-9fe8-ab3666746e54" />

With buttons inside checked:
<img width="80" src="https://github.com/user-attachments/assets/7b7e5670-1c67-4079-9087-9a46f921d1c8" /> <img width="80" src="https://github.com/user-attachments/assets/d2ffc6aa-fb4f-4e75-89f2-65468b2c986c" />


 

