### PR TITLE
[Search Map] Compact layout for cache preview header in the left sidebar

### DIFF
--- a/data/config_standard.txt
+++ b/data/config_standard.txt
@@ -317,6 +317,7 @@
   "settings_improve_character_counter": true,
   "settings_browsemap_compact_layout_sidebar": true,
   "settings_searchmap_compact_layout": true,
+  "settings_searchmap_compact_layout_cachePreviewHeader": true,
   "settings_searchmap_disabled": false,
   "settings_searchmap_disabled_strikethrough": true,
   "settings_searchmap_disabled_color": "4A4A4A",

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -680,6 +680,7 @@ var variablesInit = function(c) {
     c.settings_improve_character_counter = getValue("settings_improve_character_counter", true);
     c.settings_browsemap_compact_layout_sidebar = getValue("settings_browsemap_compact_layout_sidebar", true);
     c.settings_searchmap_compact_layout = getValue("settings_searchmap_compact_layout", true);
+    c.settings_searchmap_compact_layout_cachePreviewHeader = getValue("settings_searchmap_compact_layout_cachePreviewHeader", true);
     c.settings_searchmap_disabled = getValue("settings_searchmap_disabled", false);
     c.settings_searchmap_disabled_strikethrough = getValue("settings_searchmap_disabled_strikethrough", true);
     c.settings_searchmap_disabled_color = getValue("settings_searchmap_disabled_color", '4A4A4A');
@@ -12063,6 +12064,37 @@ var mainGC = function() {
                     if (waitCount <= 100) setTimeout(function(){compactLayoutWait(waitCount);}, 50);
                 }
             }
+
+            function compactLayout_cachePreviewHeader() {
+                if (settings_searchmap_compact_layout && settings_searchmap_compact_layout_cachePreviewHeader) {
+                    if ($('.cache-preview-header .filler')[0] && $('.cache-preview-header .header-top')[0] &&
+                        $('.cache-preview-header .header-top-left > h1')[0] && $('.cache-preview-header .status-and-type')[0] &&
+                        $('.cache-preview-header .cache-metadata-code')[0]) {
+                        if (!$('#gclh_css_cachePreviewHeader')[0]) {
+                            var css = '';
+                            css += '.cache-preview-header .filler, .cache-preview-header .header-top, .cache-preview-header .header-top-left > h1 {display: none !important}';
+                            css += '.cache-preview-header .header-top-left h1 {font-size: 16px !important;}';
+                            css += '.cache-preview-header {margin-top: 0px !important; margin-bottom: 0px !important; padding-top: 6px !important; padding-bottom: 6px !important;}';
+                            css += '.cache-preview-header h1 {margin-top: 4px !important; margin-bottom: 4px !important; padding-top: 0px !important; padding-bottom: 0px !important;}';
+                            css += '.cache-preview-header p {margin-top: 2px !important; margin-bottom: 2px !important; padding-top: 0px !important; padding-bottom: 0px !important;}';
+                            appendCssStyle(css, null, 'gclh_css_cachePreviewHeader');
+                        }
+                        if (!$('.gclh_html_cachePreviewHeader')[0]) {
+                            $('.cache-preview-header').addClass('gclh_html_cachePreviewHeader');
+                            // New line with cache name and cache link.
+                            var gccode = $('.cache-preview-header .cache-metadata-code')[0].innerHTML.trim();
+                            var gcname = $('.cache-preview-header .header-top-left > h1')[0].innerHTML;
+                            var html = '<a href="https://coord.info/' + gccode + '" rel="noopener noreferrer" target="_blank"><h1>' + gcname + '</h1></a>';
+                            $('.cache-preview-header .header-top-left').append(html);
+                            // Reduce font size in cache status displays.
+                            $('.cache-preview-header .status-and-type').children().each(function() {
+                                $(this)[0].style.setProperty('font-size', '12px', 'important');
+                            });
+                        }
+                    }
+                }
+            }
+
 //xxx deaktiviert
             function compactLayout() {
                 if (settings_searchmap_compact_layout) {
@@ -12657,6 +12689,7 @@ var mainGC = function() {
             function processAllSearchMap() {
                 scrollInCacheList();
                 setLinkToOwner(); // Has to be run before compactLayout.
+                compactLayout_cachePreviewHeader();
 //xxx deaktiviert
 //                compactLayout();
                 addVipVupMailToOwner(); // Has to be run after compactLayout.
@@ -17975,7 +18008,10 @@ var mainGC = function() {
             html += newParameterOn2;
             html += checkboxy('settings_browsemap_compact_layout_sidebar', 'Show compact layout on sidebar') + show_help("This option makes the areas \"Search for Geocaches\" and \"Filter Caches\" and the lists \"Your Pocket Queries\" and \"Caches in Advanced Search\" in the left sidebar of the browse map more compact. Both lists will then contain approximately twice as many pocket queries or caches.") + onlyBrowseMap + "<br>";
             html += newParameterVersionSetzen('0.18') + newParameterOff;
-            html += checkboxy('settings_searchmap_compact_layout', 'Show compact layout on cache detail screen') + show_help("If compact layout is enabled and the name of disabled caches are specially represented, the cache status line above the cache name is hidden.") + onlySearchMap + "<br>";
+            html += checkboxy('settings_searchmap_compact_layout', 'Show compact layout on sidebar') + show_help("This option display the areas in the left sidebar of the search map more compact.") + onlySearchMap + "<br>";
+            html += newParameterOn2;
+            html += " &nbsp; " + checkboxy('settings_searchmap_compact_layout_cachePreviewHeader', 'For cache preview header') + show_help("This option display the cache preview header area in the left sidebar of the search map more compact.<br><br>The cache preview header contains for example the cache status, the cache type, the cache link, the cache name, the last logged date, the cache code and in case of events for example the start date and time and the location.") + "<br>";
+            html += newParameterVersionSetzen('0.18') + newParameterOff;
             html += checkboxy('settings_searchmap_disabled', 'Show name of disabled caches ') + checkboxy('settings_searchmap_disabled_strikethrough', 'strike through, in color ');
             html += "<input class='gclh_form color' type='text' size=6 id='settings_searchmap_disabled_color' style='margin-left: 0px;' value='" + getValue("settings_searchmap_disabled_color", "4A4A4A") + "'>";
             html += "<img src=" + global_restore_icon + " id='restore_settings_searchmap_disabled_color' title='back to default' style='width: 12px; cursor: pointer;'>";
@@ -19547,6 +19583,7 @@ var mainGC = function() {
             setEvForDepPara("settings_default_logtype_control","settings_default_tb_logtype");
             setEvForDepPara("settings_map_overview_search_map_icon", "settings_map_overview_search_map_icon_new_tab");
             setEvForDepPara("settings_map_show_btn_hide_header","settings_hide_map_header");
+            setEvForDepPara("settings_searchmap_compact_layout","settings_searchmap_compact_layout_cachePreviewHeader");
             setEvForDepPara("settings_searchmap_show_btn_save_as_pq","settings_save_as_pq_set_all");
             setEvForDepPara("settings_show_enhanced_map_popup","settings_show_latest_logs_symbols_count_map");
             setEvForDepPara("settings_show_enhanced_map_popup","settings_show_country_in_place");
@@ -20094,6 +20131,7 @@ var mainGC = function() {
                 'settings_improve_character_counter',
                 'settings_browsemap_compact_layout_sidebar',
                 'settings_searchmap_compact_layout',
+                'settings_searchmap_compact_layout_cachePreviewHeader',
                 'settings_searchmap_disabled',
                 'settings_searchmap_disabled_strikethrough',
                 'settings_searchmap_show_hint',


### PR DESCRIPTION
Related to #2708.

This option display the cache preview header area in the left sidebar of the search map more compact.
The cache preview header contains the most important data about the cache, such as cache status, cache type, cache link, cache name, last logged date, cache code and in case of events further data such as start date and time and location.

For a cache without and with compact layout:
<img width="387" height="140" alt="Screen08" src="https://github.com/user-attachments/assets/684b060d-91a7-4fd3-916c-709b6f82292e" />(Screen08.jpg)

<img width="387" height="80" alt="Screen07" src="https://github.com/user-attachments/assets/edd9aa91-2590-44d2-a3ea-4dc58924b4fc" />(Screen07.jpg)

For an event without and with compact layout:
<img width="388" height="187" alt="Screen10" src="https://github.com/user-attachments/assets/946ce838-b16c-4a02-ae3a-f8a0bd10247d" />(Screen10.jpg)

<img width="387" height="96" alt="Screen09" src="https://github.com/user-attachments/assets/0d68f12e-e8ec-4951-8808-1378bd6d72a5" />(Screen09.jpg)

`settings_searchmap_compact_layout_cachePreviewHeader`
<img width="304" height="47" alt="Screen11" src="https://github.com/user-attachments/assets/f31788f2-fc75-4367-8246-257ae5d21dad" />(Screen11.jpg)
