### PR TITLE
[Config] Improve align of version info after parameter, otherwise, premature line breaks may occur

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -20306,7 +20306,7 @@ var mainGC = function() {
     newParameterLL3 = s.replace("#", "03");
 //<-- $$001
     function newParameterVersionSetzen(version) {
-        var newParameterVers = "<span style='font-size: 70%; font-style: italic; float: right; margin-top: -14px; margin-right: 4px;' ";
+        var newParameterVers = "<span style='font-size: 70%; font-style: italic; float: right; margin-top: -15px; margin-right: 4px;' ";
         if (version != "") newParameterVers += "title='Implemented with version " + version + "'>" + version + "</span>";
         else newParameterVers += "></span>";
         if (settings_hide_colored_versions) newParameterVers = "";


### PR DESCRIPTION
Related to #3093 (undocumented).

For example: The search map icon wrap in the next line.
<img width="886" height="133" alt="config line breaks" src="https://github.com/user-attachments/assets/7614ba7f-18b7-4548-8189-06dee8ec8dce" />

