### PR TITLE
[Search, My Lists, Cache Owner Dashboard] Automatic setting of the default language doesn't work due to asynchronous loading of footer

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -1579,7 +1579,7 @@ var mainGC = function() {
     tlc('START Set language');
     try {
         var langu_string = langus_code[langus.indexOf(settings_default_langu)] + '-';
-        if (settings_set_default_langu && !global_locale.match(langu_string)) {
+        if (settings_set_default_langu && !global_locale.match(langu_string) && !is_page("map") && !is_page("searchmap")) {
             function waitForLanguageSelector(waitCount) {
                 if ($('.language-selector button')[0]) {
                     $('.language-selector button')[0].click();
@@ -1594,6 +1594,9 @@ var mainGC = function() {
                         window.scroll(0, 0);
                     }
                     waitForLanguagePopover(0);
+                } else if ($('#footer-placeholder')[0]) {
+                    window.scrollTo(0, document.body.scrollHeight);
+                    waitCount++; if (waitCount <= 500) setTimeout(function(){waitForLanguageSelector(waitCount);}, 10);
                 } else {waitCount++; if (waitCount <= 500) setTimeout(function(){waitForLanguageSelector(waitCount);}, 10);}
             }
             waitForLanguageSelector(0);


### PR DESCRIPTION
The automatic setting of the default language doesn't work on the following pages because the footer is only available as a placeholder and is only loaded when it is supposed to appear on the screen when scrolling down. This can be fixed. 
- Search https://www.geocaching.com/play/search
- My Lists https://www.geocaching.com/plan/lists and subpages
- Cache Owner Dashboard https://www.geocaching.com/play/owner and subpages

---
This doesn't work on the Search Map and Browse Map because they don't have a footer. Therefore, remove both websites from this processing.
