### PR TITLE
[Search Map, Browse Map] Improve links in Go to button

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13612,6 +13612,7 @@ var mainGC = function() {
         css += '.gclh-leaflet-list > a {display: table; padding: 2px 6px; font-size: 13px; color: #000000; cursor: pointer; min-width: 135px; text-align: left;}';
         css += '.gclh-leaflet-control:hover .gclh-leaflet-list {display: block;}';
         css += '.gclh-leaflet-list a:hover {background-color: #e6f7ef; text-decoration: none;}';
+        css += '#gclh_geoservices_list a {width: -webkit-fill-available; text-decoration: none;}';
         appendCssStyle(css, null, 'gclh_geoservices_css');
     }
 


### PR DESCRIPTION
Upon hovering, the entries are not fully highlighted in green, and the link extends only up to the "min-width", or rather, up to the length of the entry itself.

Before:
<img width="268" height="116" alt="1" src="https://github.com/user-attachments/assets/6e5900d8-5fa4-46d0-88be-9ad7e1aefae6" />
<img width="270" height="110" alt="2" src="https://github.com/user-attachments/assets/680d6151-7744-4b2b-b86b-1ce5925a51bd" />

After:
<img width="277" height="114" alt="3" src="https://github.com/user-attachments/assets/c81b410d-18b8-4eef-9946-a0d72bb4436d" />

---
Tested with both Maps and under Firefox and Chrome.
