### PR TITLE
[Search Map] On small screens list/map selector is hidden behind gclh map buttons

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13099,6 +13099,8 @@ var mainGC = function() {
                 css += 'div:has(>.browse-map-link) span {display: none;}';
                 css += '.browse-map-link, [data-testid="create-route-map"] {width: 40px !important;}';
             }
+            // If viewport is smaller than 768px, then sidebar is hidden and GS List/Map control shows up and covers gclh buttons. Therefore move GS control left of gclh buttons.
+            css += '@media (width < 768px) { div.tablet\\:hidden:has(> ul[aria-label="List / Map"]) {position: absolute; top: 8px; right: ' + (mr+8) + 'px;} }';
             // Sidebar Enhancements.
             if (settings_show_enhanced_map_popup) {
                 css += '.cache-preview-attributes .geocache-owner {margin-bottom: 3px;}';


### PR DESCRIPTION
On small screens (< 768px) the gclh map buttons overlap the GS list/map selector.
Now, the gclh map buttons keep their position and the GS list/map selector is moved left of the buttons.

Before:
<img width="150" alt="image" src="https://github.com/user-attachments/assets/8a240212-436d-44b1-9dd5-296633a6af87" />
After:
<img width="150" alt="image" src="https://github.com/user-attachments/assets/2f4d417e-b4f5-47f0-ab9c-9b2513cd9bb1" />