### PR TITLE
[Search Map] Add to list dialog on smaller screens doesn't work

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -12399,18 +12399,18 @@ var mainGC = function() {
             function compactLayout_cachePreviewActionMenu() {
                 if (settings_searchmap_compact_layout && settings_searchmap_compact_layout_cachePreviewActionMenu) {
                     if ($('.cache-preview-action-menu a.log-geocache')[0] && $('.cache-preview-action-menu ul > li button svg')[0] &&
-                        $('.cache-preview-action-menu ul > li span')[0]) {
+                        $('.cache-preview-action-menu ul > li span')[0] && !$('.cache-preview-action-menu dialog')[0]) {
                         if (!$('#gclh_css_cachePreviewActionMenu')[0]) {
                             var buttonLineHeight = parseInt(settings_searchmap_compact_layout_cachePreviewActionMenu_buttonHeight);
                             var pad = 12 - ( 46 - buttonLineHeight ) / 2;
                             var css = '';
-                            css += '.cache-preview-action-menu {padding-top: 5px !important; padding-bottom: 5px !important; margin: 0px !important;}';
-                            css += '.cache-preview-action-menu a.log-geocache {padding-top: ' + pad + 'px !important; padding-bottom: ' + pad + 'px !important; margin: 0px 0px 5px 0px !important;}';
-                            css += '.cache-preview-action-menu ul {padding: 0px !important; margin: 0px !important; gap: 5px !important;}';
-                            css += '.cache-preview-action-menu ul > li button, .cache-preview-action-menu ul > li a {padding-top: ' + (pad - 2) + 'px !important; padding-bottom: ' + (pad - 2) + 'px !important;}';
-                            css += '.cache-preview-action-menu ul > li svg, .cache-preview-action-menu ul > li img {margin: 0px auto 0px auto !important;}';
-                            css += '.cache-preview-action-menu ul > li span:not(:has(> span.gclh_ownBMLs_count)):not(.gclh_ownBMLs_count) {display: none !important;}';
-                            css += '.cache-preview-action-menu ul > li span.gclh_ownBMLs_count {position: absolute; margin: -12px 0px 0px 12px;}';
+                            css += '.cache-preview-action-menu:not(:has(dialog)) {padding-top: 5px !important; padding-bottom: 5px !important; margin: 0px !important;}';
+                            css += '.cache-preview-action-menu:not(:has(dialog)) a.log-geocache {padding-top: ' + pad + 'px !important; padding-bottom: ' + pad + 'px !important; margin: 0px 0px 5px 0px !important;}';
+                            css += '.cache-preview-action-menu:not(:has(dialog)) ul {padding: 0px !important; margin: 0px !important; gap: 5px !important;}';
+                            css += '.cache-preview-action-menu:not(:has(dialog)) ul > li button, .cache-preview-action-menu:not(:has(dialog)) ul > li a {padding-top: ' + (pad - 2) + 'px !important; padding-bottom: ' + (pad - 2) + 'px !important;}';
+                            css += '.cache-preview-action-menu:not(:has(dialog)) ul > li svg, .cache-preview-action-menu:not(:has(dialog)) ul > li img {margin: 0px auto 0px auto !important;}';
+                            css += '.cache-preview-action-menu:not(:has(dialog)) ul > li span:not(:has(> span.gclh_ownBMLs_count)):not(.gclh_ownBMLs_count) {display: none !important;}';
+                            css += '.cache-preview-action-menu:not(:has(dialog)) ul > li span.gclh_ownBMLs_count {position: absolute; margin: -12px 0px 0px 12px;}';
                             appendCssStyle(css, null, 'gclh_css_cachePreviewActionMenu');
                         }
                         // Number of items want to display in the buttons line.


### PR DESCRIPTION
The "Add to list" dialog does not display any bookmark lists.

Before:
<img width="612" height="261" alt="before" src="https://github.com/user-attachments/assets/232e796e-5164-4ce5-a9f2-2c410c028c1b" />

After:
<img width="613" height="302" alt="after" src="https://github.com/user-attachments/assets/4dc83ef3-4713-4c7c-a2b5-c5ba52830df1" />

To Reproduce:
1. Activate [Show compact layout on sidebar - For cache preview action menu](https://www.geocaching.com/my/#GClhShowConfig#a#settings_searchmap_compact_layout_cachePreviewActionMenu)
2. https://www.geocaching.com/play/map with smaller screen as 768 pixel.
[Edit]<del>3. Click to "Add to a list" button</del>
3. Click to a Cache Icon
4. Click to "Add to a list" button