### PR TITLE
[Browse Map] Hide found caches, own caches and DNF smileys by default do not work since last update of the website

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13735,20 +13735,17 @@ var mainGC = function() {
             function hideFoundCaches() {
                 // Kartenfilter bei externen Filtern (beispielsweise aus play/search) nicht verändern.
                 if (document.location.href.match(/&asq=/)) return;
-                var button = unsafeWindow.document.getElementById("m_myCaches").childNodes[1];
-                if (button) button.click();
+                if ($('.ct_mf')[0]) $('.ct_mf')[0].click();
             }
             if (settings_map_hide_found) isMapLoad(hideFoundCaches);
             function hideHiddenCaches() {
                 if (document.location.href.match(/&asq=/)) return;
-                var button = unsafeWindow.document.getElementById("m_myCaches").childNodes[3];
-                if (button) button.click();
+                if ($('.ct_mo')[0]) $('.ct_mo')[0].click();
             }
             if (settings_map_hide_hidden) isMapLoad(hideHiddenCaches);
             function removeDNFSmileys() {
                 if (document.location.href.match(/&asq=/)) return;
-                var button = unsafeWindow.document.getElementById("m_myCaches").childNodes[5];
-                if (button) button.click();
+                if ($('.ct_mdnf')[0]) $('.ct_mdnf')[0].click();
             }
             if (settings_map_hide_dnfs) isMapLoad(removeDNFSmileys);
             function getAllCachetypeButtons() {


### PR DESCRIPTION
Hide found caches by default, hide own caches by default and hide DNF smileys by default do not work since last update of the Browse Map website.

<img width="328" height="82" alt="grafik" src="https://github.com/user-attachments/assets/fee502af-3d4f-49b2-ac87-aef3e6b6ba20" />

Related to #3177.


