### PR TITLE
[Browse Map] Move zoom buttons again top left

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13207,6 +13207,9 @@ var mainGC = function() {
             var css = '';
             // Damit auch mehr als 2 rechte Buttons handlebar.
             css += '.leaflet-control-layers + .leaflet-control {position: unset; right: unset;} .leaflet-control {clear: left}';
+            // Move zoom buttons again top left and animate moving of zoom buttons if sidebar moves.
+            css += '.leaflet-control-zoom {position: relative !important; left: 30px !important; transition: left 0.52s ease-in-out !important; top: 52px !important; bottom: 0px !important; right: 0px !important; margin: 0px 0px 0px 1px !important; transform: unset !important; z-index: 7 !important;}';
+            css += 'body:has(.Sidebar.Open) .leaflet-control-zoom {left: 385px !important;}';
             // Improve the scale lines on the left side.
             css += '.leaflet-control-scale {margin-bottom: 18px !important; margin-left: 1px !important;}';
             css += '.leaflet-control-scale-line:first-child {box-shadow: 0 -1px 5px rgba(0, 0, 0, 0.2) !important;}';


### PR DESCRIPTION
Move zoom buttons on Browse Map again top left and animate moving of zoom buttons if sidebar moves.

Before:
<img width="193" height="193" alt="before" src="https://github.com/user-attachments/assets/3eb5daef-5f28-413c-a6d4-6325d0b2825f" />

After:
<img width="295" height="157" alt="after" src="https://github.com/user-attachments/assets/37d33dc7-21d0-4719-810b-f658852d7092" />

Related to #3177.
