### PR TITLE
[Browse Map] Prevent tooltip with cache name if cache detail pop-up is available

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13213,7 +13213,7 @@ var mainGC = function() {
             // Improve clickability on list names of add to list pop up.
             css += '.add-list li button {width: 100%; text-align: left;} .pop-modal .status {width: initial;}';
             // Prevent tooltip with cache name if cache detail pop-up is available.
-            css += '.leaflet-container:has(.leaflet-popup) .map-tooltip {display: none !important;}';
+            css += '.leaflet-container:has(.leaflet-popup-content-wrapper:hover) .map-tooltip {display: none !important;}';
             appendCssStyle(css);
         } catch(e) {gclh_error("Improve Browse Map",e);}
     }


### PR DESCRIPTION
Related to #3082.

Prevent tooltip with cache name if cache detail pop-up is available. This prevents tooltips with cache names from caches located below the cache detail pop-up from overlapping the cache detail pop-up.

This now takes place exclusively in the pop-up area. (This is the improvement to #3082.)

<img width="517" height="331" alt="Browse Map title bei Popup" src="https://github.com/user-attachments/assets/e8daddc7-6b2d-4b55-9f97-5085492680b9" />
