### PR TITLE
[Browse Map] Set default map layer no longer works if GME is running

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13355,7 +13355,8 @@ var mainGC = function() {
                     if (name == settings_map_default_layer) defaultLayer = name;
                     else if (defaultLayer == "") defaultLayer = name;
                 }
-                var labels = $('.leaflet-control-layers.gclh_layers.gclh_used .leaflet-control-layers-base').find('label');
+                // Der Default Layer wurde bereits gesetzt. Hier muss er erneut gesetzt werden wegen möglicher Änderungen durch GME.
+                var labels = $('.leaflet-control-layers.gclh_layers.gclh_used .leaflet-control-layers-base').find('label > span');
                 if (labels) {
                     if (is_page("map")) {
                         for (var i=0; i<labels.length; i++) {


### PR DESCRIPTION
Set default map layer on Browse Map no longer works if GME is running.

Related to #3187: 
[Browse Map] Some features are no longer working correctly due to the new website release (01.06.2026) and the switch to Leaflet 1.9.4.