### PR TITLE
[Browse Map] Shadow above the buttons top right caused by dummy layer

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13322,6 +13322,7 @@ var mainGC = function() {
                             if (document.location.pathname.match(/^\/map/)) {
                                 var div = document.createElement("div");
                                 div.setAttribute("class", "gclh_dummy gclh_used");
+                                div.setAttribute("style", "display: none;");
                                 var aTag = document.createElement("a");
                                 aTag.setAttribute("class", "leaflet-control-layers dummy_for_gme gclh_dummy gclh_used");
                                 div.appendChild(aTag);


### PR DESCRIPTION
Shadow above the buttons top right caused by dummy layer.
<img width="349" height="147" alt="Screenshot 2026-06-10 081942" src="https://github.com/user-attachments/assets/25f04979-5b68-4749-9e00-1483d351f63d" />

Related to #3187.
