### PR TITLE
[Browse Map] Prevent close button on cache details screen from overlapping GC code

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13879,7 +13879,6 @@ var mainGC = function() {
             var target = document.querySelector('.leaflet-popup-pane');
 
             var css = '';
-//xxxx ok das hier prüfen. Sitzt das Popup noch richtig über dem Icon?
             css += ".leaflet-popup-content-wrapper, .leaflet-popup-close-button {margin: 16px 3px 0px 13px !important;}";
             css += ".leaflet-popup-content {margin-left: 10px !important; margin-right: 10px !important;}";
             css += "#gmCacheInfo h4 a, #gmCacheInfo dl a, #gmCacheInfo dl a span, #gmCacheInfo .links:not(.popup_additional_info) a {text-decoration-line: none !important;}";

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13231,6 +13231,9 @@ var mainGC = function() {
             css += '.legacy-map-zoom-wrapper {z-index: auto}';
             // Slight opacity for zomm buttons.
             css += '.leaflet-control-zoom {opacity: 0.8}';
+            // Prevent close button on cache details screen from overlapping GC code, make height and width of close button proportional and set a hover effect.
+            css += '.leaflet-container a.leaflet-popup-close-button {padding: 0px; top: -8px; right: -8px; width: 22px; height: 22px; font: 16px/19px Tahoma, Verdana, sans-serif;}';
+            css += '.leaflet-container a.leaflet-popup-close-button:hover, .leaflet-container a.leaflet-popup-close-button:focus {color: #fff;}';
             appendCssStyle(css);
         } catch(e) {gclh_error("Improve Browse Map",e);}
     }
@@ -13876,6 +13879,7 @@ var mainGC = function() {
             var target = document.querySelector('.leaflet-popup-pane');
 
             var css = '';
+//xxxx ok das hier prüfen. Sitzt das Popup noch richtig über dem Icon?
             css += ".leaflet-popup-content-wrapper, .leaflet-popup-close-button {margin: 16px 3px 0px 13px !important;}";
             css += ".leaflet-popup-content {margin-left: 10px !important; margin-right: 10px !important;}";
             css += "#gmCacheInfo h4 a, #gmCacheInfo dl a, #gmCacheInfo dl a span, #gmCacheInfo .links:not(.popup_additional_info) a {text-decoration-line: none !important;}";


### PR DESCRIPTION
Prevent the close button on the cache details on the Browse Map screen from overlapping GC code.

Additional:
Make height and width of the close button on the Browse Map proportional and set hover effect.

Before
<img width="661" height="69" alt="1" src="https://github.com/user-attachments/assets/d7c4d851-4b29-4fd5-91cb-2c0f6bd36df1" />

After
<img width="664" height="64" alt="2" src="https://github.com/user-attachments/assets/3782c804-6986-45e7-b664-17401a2ceb86" />
