### PR TITLE
[Log Form] Missing F2 feature on post button

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -5265,8 +5265,8 @@ var mainGC = function() {
 
             // Send Log with F2.
             function buildSendLogWithF2(waitCount) {
-                if ($('.post-button-container button.gc-button-primary')[0] && !$('.post-button-container button.gc-button-primary')[0].innerHTML.match(/\s\(F2\)/)) {
-                    let logBtn = $('.post-button-container button.gc-button-primary')[0];
+                if ($('.post-button-container button')[0] && !$('.post-button-container button')[0].innerHTML.match(/\s\(F2\)/)) {
+                    let logBtn = $('.post-button-container button')[0];
                     function keydownF2(e) {
                         if (!check_config_page()) {
                             if (e.keyCode == 113 && noSpecialKey(e)) {


### PR DESCRIPTION
Missing F2 feature on post button of the log form.

Before:
<img width="409" height="78" alt="1" src="https://github.com/user-attachments/assets/47008623-fa1a-4e03-9bd3-dbebb954dc07" />

After:
<img width="450" height="73" alt="2" src="https://github.com/user-attachments/assets/be925099-ed1f-4398-863f-42832b9554df" />


