### PR TITLE
[PQ Splitter] PQs for region "Buskerud" can not created via PQ Splitter because of changed PQ id

### DIFF
--- a/data/init.js
+++ b/data/init.js
@@ -484,7 +484,7 @@ function states_idInit(c) {
         {"n":"Budapest","id":"438"},
         {"n":"Burgenland","id":"258"},
         {"n":"Busan","id":"297"},
-        {"n":"Buskerud","id":"244"},
+        {"n":"Buskerud","id":"534"},
         {"n":"Calabria","id":"192"},
         {"n":"California","id":"5"},
         {"n":"Campania","id":"193"},


### PR DESCRIPTION
GS has changed the PQ id for "Buskerud" to 534. The PQs for this region can not created via PQ Splitter. 

Related to https://github.com/2Abendsegler/GClh/pull/2930#issuecomment-4683069056
