### PR TITLE
[Hide] Align info of length for field cachename and field placed by

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -15415,7 +15415,8 @@ var mainGC = function() {
             createCounterElement('placedByCounter', placedBy);
             createCounterElement('hintCounter', hint);
             var css = '#nameCounter, #placedByCounter, #hintCounter {text-align: right;}';
-            css += '#nameCounter, #placedByCounter {width: 400px;}';
+            css += '#nameCounter, #placedByCounter {width: 52%;}';
+            css += '.edit-cache-form #nameCounter, .edit-cache-form #placedByCounter {width: 400px;}';
             appendCssStyle(css);
         } catch(e) {gclh_error("Show length of hint, cachename and placed by on hide edit page",e);}
     }


### PR DESCRIPTION
Improve alignment of the info of length for the field cachename and the field placed by on hide cache page.

Before: Hide cache - Edit cache
<img width="350" alt="1" src="https://github.com/user-attachments/assets/00d12992-a125-491b-899e-96d4399410bf" /> <img width="250" alt="2" src="https://github.com/user-attachments/assets/50aaa733-51c7-41ff-94ae-bfff3af0bae8" />

After: Hide cache - Edit cache
<img width="350" alt="3" src="https://github.com/user-attachments/assets/9a13be57-e752-4f46-a041-300501e7450a" /> <img width="250" alt="2" src="https://github.com/user-attachments/assets/50aaa733-51c7-41ff-94ae-bfff3af0bae8" /> 


