### PR TITLE
[Browse Map] Remove unnecessary widening of the cache detail pop-up

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13890,7 +13890,7 @@ var mainGC = function() {
 
             var css = '';
             css += ".leaflet-popup-content-wrapper, .leaflet-popup-close-button {margin: 16px 3px 0px 13px !important;}";
-            css += ".leaflet-popup-content {margin-left: 10px !important; margin-right: 10px !important;}";
+            css += ".leaflet-popup-content {width: 400px !important; margin-left: 10px !important; margin-right: 10px !important;}";
             css += "#gmCacheInfo {color: rgb(74 74 74);}";
             css += "#gmCacheInfo h4 a, #gmCacheInfo dl a, #gmCacheInfo dl a span, #gmCacheInfo .links:not(.popup_additional_info) a {text-decoration-line: none !important;}";
             css += "#gmCacheInfo h4 a:hover, #gmCacheInfo dl a:hover, #gmCacheInfo dl a span:hover, #gmCacheInfo .links:not(.popup_additional_info) a:hover {text-decoration-line: underline !important;}";


### PR DESCRIPTION
Remove the unnecessary widening of the cache detail pop-up on Browse Map.

Perhaps the widening was implemented to get a handle on the line-break issues discussed in the GC forum in the threads [here](https://forums.geocaching.com/GC/index.php?/topic/437464-browse-map-cache-details-ui-bug/) and [here](https://forums.geocaching.com/GC/index.php?/topic/434278-bug-cache-details-are-incorrectly-formatted-on-the-browse-map), as well as elsewhere.

The row containing the links can be used for a size comparison.

Before: .leaflet-popup-content width: 451px
<img width="542" alt="1" src="https://github.com/user-attachments/assets/355a9e87-ef07-4bd1-acd5-36f89a6f3c99" />

After: .leaflet-popup-content width: 400px !important
<img width="486" alt="2" src="https://github.com/user-attachments/assets/80aa0e39-f553-478b-82bf-87b954fc8c09" />

In comparison: Before both on 28.03.2026 with GClh v0.18.2: .leaflet-popup-content width: ~400px
<img width="486" alt="Popup normale größe2 2" src="https://github.com/user-attachments/assets/0dd87428-e796-46be-9343-f1dcd371ccdb" />

---
Testing:
- Testing with Languages: English, German, Czech
- Testing with different date formats: 2026-06-14, 14 Jul 2026
- Testing with Firefox, Chrome
- Caches
- Events
