### PR TITLE
[Browse Map] Improve line-break for log totals in the cache detail pop-up

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -14037,7 +14037,7 @@ var mainGC = function() {
                             else var place = $(text).find('#ctl00_ContentBody_Location')[0].innerHTML.replace(/(.*?)\s/,'');
 
                             // Put all together.
-                            var new_text = '<span style="margin-right: 5px;">Logs:</span>' + all_logs + '<br>';
+                            var new_text = '<div style="display: flex;"><span style="margin-right: 5px;">Logs:</span>' + all_logs + '</div>';
                             new_text += $(last_logs).prop('outerHTML');
                             new_text += '<div style="padding-bottom: 3px;">';
 


### PR DESCRIPTION
Before:
<img width="400" alt="1" src="https://github.com/user-attachments/assets/46cc86c9-06b3-4f4a-87eb-80d6ee6e4524" />

After:
<img width="400" alt="2" src="https://github.com/user-attachments/assets/78ae7ba5-06a0-48f2-9af0-26d33a0644dd" />
