### PR TITLE
[Browse Map] Make line-break for line with links in the cache detail pop-up possible again

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13217,6 +13217,9 @@ var mainGC = function() {
             css += '.leaflet-container:has(.leaflet-popup-content-wrapper:hover) .map-tooltip {display: none !important;}';
             // Improve the scale block on the left side.
             css += '.leaflet-control-scale {margin-left: 1px !important;}';
+            // Make line-break for line with links in the cache detail pop-up possible.
+            css += ".gm-browse-map .map-item .links {overflow: visible !important; text-overflow: unset !important; white-space: unset !important;}";
+            css += ".gm-browse-map .map-item .links a {display: inline-block;}";
             // Shared styles for GClh and GME:
             // - Resize map layer control button.
             css += 'a.leaflet-control-layers-toggle {width: 36px !important; height: 36px !important;}';


### PR DESCRIPTION
Make a line-break for the line with links in the cache detail pop-up possible again. Particularly for German and when using additional links such as Send2cgeo.

Before:
<img width="400" alt="3" src="https://github.com/user-attachments/assets/3fca8b06-b996-4c10-9dc4-819a8f69eb46" />

After:
<img width="400" alt="4" src="https://github.com/user-attachments/assets/3bdc975d-5b61-4f8c-b0c2-0e3b5c8ac306" />
