### PR TITLE
[Browse Map] Improve opening position of the cache detail pop-up

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13893,19 +13893,23 @@ var mainGC = function() {
 
             // Improve opening position of the cache detail pop-up.
             window.addEventListener('load', () => {
-                const map = unsafeWindow.MapSettings.Map;
-                if (map) {
-                    map.on('popupopen', function(e) {
-                        const popup = e.popup;
-                        if ($('.Sidebar.Open')[0]) var left = 360;
-                        else var left = 6;
-                        var top = -40;
-                        var right = 8;
-                        var bottom = 200;
-                        popup.options.autoPanPaddingTopLeft = [left, top];
-                        popup.options.autoPanPaddingBottomRight = [right, bottom];
-                        popup.update();
-                    });
+                if (unsafeWindow.MapSettings?.Map) {
+                    const map = unsafeWindow.MapSettings.Map;
+                    if (map) {
+                        map.on('popupopen', function(e) {
+                            if (e.popup) {
+                                const popup = e.popup;
+                                if ($('.Sidebar.Open')[0]) var left = 360;
+                                else var left = 6;
+                                var top = -40;
+                                var right = 8;
+                                var bottom = 200;
+                                popup.options.autoPanPaddingTopLeft = [left, top];
+                                popup.options.autoPanPaddingBottomRight = [right, bottom];
+                                popup.update();
+                            }
+                        });
+                    }
                 }
             });
 

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13901,8 +13901,8 @@ var mainGC = function() {
                                 const popup = e.popup;
                                 if ($('.Sidebar.Open')[0]) var left = 360;
                                 else var left = 6;
-                                var top = -40;
-                                var right = 8;
+                                var top = 20;
+                                var right = 42;
                                 var bottom = 200;
                                 popup.options.autoPanPaddingTopLeft = [left, top];
                                 popup.options.autoPanPaddingBottomRight = [right, bottom];
@@ -13915,7 +13915,7 @@ var mainGC = function() {
 
             var css = '';
             css += ".leaflet-popup-content-wrapper, .leaflet-popup-close-button {margin: 16px 3px 0px 13px !important;}";
-            css += ".leaflet-popup-content {width: 400px !important; margin-left: 10px !important; margin-right: 10px !important;}";
+            css += ".leaflet-popup-content {width: 406px !important; margin-left: 10px !important; margin-right: 10px !important;}";
             css += "#gmCacheInfo {color: rgb(74 74 74);}";
             css += "#gmCacheInfo h4 a, #gmCacheInfo dl a, #gmCacheInfo dl a span, #gmCacheInfo .links:not(.popup_additional_info) a {text-decoration-line: none !important;}";
             css += "#gmCacheInfo h4 a:hover, #gmCacheInfo dl a:hover, #gmCacheInfo dl a span:hover, #gmCacheInfo .links:not(.popup_additional_info) a:hover {text-decoration-line: underline !important;}";
@@ -14120,11 +14120,11 @@ var mainGC = function() {
                                 original_coords = original_coords.replace("oldLatLngDisplay\":\"","");
                                 original_coords = original_coords.replace("\"","");
                                 original_coords = original_coords.replace(new RegExp('\'', 'g'),'');
-                                original_coords_span = ' <span class="coordinates original" title="original Coordinates">&nbsp;( <span class="anker"></span>' + original_coords + ' )</span>';
+                                original_coords_span = ' <span class="coordinates original" title="original Coordinates">&nbsp;( <span class="anker"></span> ' + original_coords + ' )</span>';
                                 corrected = "corrected ";
                             }
                             if (settings_show_enhanced_map_coords) {
-                                new_text += '<span><span class="coordinates current" title="'+corrected+'Coordinates">' + coords + '</span>' + original_coords_span + '</span>';
+                                new_text += '<span><span class="coordinates current" title="'+corrected+'Coordinates"> ' + coords + '</span>' + original_coords_span + '</span>';
                             }
 
                             $('#popup_additional_info_' + local_gc_code).html(new_text);

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13891,6 +13891,24 @@ var mainGC = function() {
             // Select the target node.
             var target = document.querySelector('.leaflet-popup-pane');
 
+            // Improve opening position of the cache detail pop-up.
+            window.addEventListener('load', () => {
+                const map = unsafeWindow.MapSettings.Map;
+                if (map) {
+                    map.on('popupopen', function(e) {
+                        const popup = e.popup;
+                        if ($('.Sidebar.Open')[0]) var left = 360;
+                        else var left = 6;
+                        var top = -40;
+                        var right = 8;
+                        var bottom = 200;
+                        popup.options.autoPanPaddingTopLeft = [left, top];
+                        popup.options.autoPanPaddingBottomRight = [right, bottom];
+                        popup.update();
+                    });
+                }
+            });
+
             var css = '';
             css += ".leaflet-popup-content-wrapper, .leaflet-popup-close-button {margin: 16px 3px 0px 13px !important;}";
             css += ".leaflet-popup-content {width: 400px !important; margin-left: 10px !important; margin-right: 10px !important;}";


### PR DESCRIPTION
By default, the cache detail pop-up tends to open too low down, requiring the map to be shifted upwards to view log texts or personal note texts. Additionally, pop-ups open behind the sidebar.

This behavior is improved here for cases where the additional data is to be displayed within the cache detail pop-up.

Known issue: If a line break occurs in the "Logs" (log totals), the pop-up shifts slightly upwards. However, this does not happen often.
Other line breaks, such as in the line containing the links, are already present, and the pop-up shift takes them into account.

After changes: [replaced]
<img width="800" alt="GIF" src="https://github.com/user-attachments/assets/2aa26c25-41f3-4b55-b3a4-e78fffdb0dad" />


