### PR TITLE
[Browse Map] Fix improve opening position and remove unnecessary widening of the cache detail pop-up

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -13897,7 +13897,7 @@ var mainGC = function() {
                     const map = unsafeWindow.MapSettings.Map;
                     if (map) {
                         map.on('popupopen', function(e) {
-                            if (e.popup) {
+                            if (e.popup._content?.firstChild?.id == 'gmCacheInfo') {
                                 const popup = e.popup;
                                 if ($('.Sidebar.Open')[0]) var left = 360;
                                 else var left = 6;
@@ -13915,7 +13915,7 @@ var mainGC = function() {
 
             var css = '';
             css += ".leaflet-popup-content-wrapper, .leaflet-popup-close-button {margin: 16px 3px 0px 13px !important;}";
-            css += ".leaflet-popup-content {width: 406px !important; margin-left: 10px !important; margin-right: 10px !important;}";
+            css += ".leaflet-popup-content:has(.popup_additional_info) {width: 406px !important; margin-left: 10px !important; margin-right: 10px !important;}";
             css += "#gmCacheInfo {color: rgb(74 74 74);}";
             css += "#gmCacheInfo h4 a, #gmCacheInfo dl a, #gmCacheInfo dl a span, #gmCacheInfo .links:not(.popup_additional_info) a {text-decoration-line: none !important;}";
             css += "#gmCacheInfo h4 a:hover, #gmCacheInfo dl a:hover, #gmCacheInfo dl a span:hover, #gmCacheInfo .links:not(.popup_additional_info) a:hover {text-decoration-line: underline !important;}";


### PR DESCRIPTION
Die Positionierung und Breite eines Pop-ups auf der Browse Map sollte mit den Anpassungen nur noch für das Cache Detail Pop-up erfolgen und nicht mehr für GME Pop-ups.

Testing:
- GClh und GME aktivieren.
- https://www.geocaching.com/map

Cache Detail Pop-up testen:
- Auf ein Cache Icon klicken: 
° Es findet die neue Positionierung statt. 
° Im Inspektor ".leaflet-popup-content-wrapper .leaflet-popup-content" angeben. Breite ist 406px.

GME Route Point Pop-up testen:
- Auf GME Route Tool klicken.
- Irgendwo auf die Karte klicken um damit einen GME Route Point zu setzen.
- Auf den GEM Route Point klicken. 
° Es findet nicht die neue Positionierung statt. Die Position wird nur am Rand der Karte korrigiert, damit das gesamte Pop-up sichtbar wird.  
° Im Inspektor ".leaflet-popup-content-wrapper .leaflet-popup-content" angeben. Breite ist 139px.

---
Related to #3226