### PR TITLE
[Listing] Prevent areas from flashing white when zooming the overview map

### DIFF
--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -3467,6 +3467,8 @@ var mainGC = function() {
             css += '.mapIconRight svg {padding: 3px;}';
             css += '.search_map_icon {margin-left: 2px !important;}';
             if (!settings_map_overview_search_map_icon) css += '.browse_map_icon {margin-top: 1px;}';
+            // Prevent areas from flashing white when zooming.
+            css += '#gclh_map_overview.leaflet-container img.leaflet-tile {mix-blend-mode: normal !important;}';
             appendCssStyle(css);
             var html = "";
             html += "<div class='CacheDetailNavigationWidget' style='margin-top: 1.5em;'>";


### PR DESCRIPTION
Before:
<img width="236" height="233" alt="1" src="https://github.com/user-attachments/assets/bacaca26-3e42-484b-bf65-8a24e90d3d0d" />

After:
<img width="236" height="233" alt="2" src="https://github.com/user-attachments/assets/04216cf3-32a5-48c1-91b1-756d3fb2f0ba" />
