### PR TITLE
[Shareables] Integrate "Shareable" links in Play menue and Linklist

### DIFF
--- a/data/header.html
+++ b/data/header.html
@@ -46,6 +46,9 @@
                         <a id="ctl00_ctl29_hlSubNavLists" accesskey="t" data-event-action="Header Click" data-event-category="data" data-event-label="Lists" href="/account/lists/">Lists</a>
                     </li>
                     <li>
+                        <a id="ctl00_ctl29_hlSubNavShareables" accesskey="t" data-event-action="Header Click" data-event-category="data" data-event-label="Shareables" href="/play/shareables">Shareables</a>
+                    </li>
+                    <li>
                         <a id="ctl00_ctl29_hlSubNavTrackables" accesskey="t" data-event-action="Header Click" data-event-category="data" data-event-label="Trackables" href="/track/">Trackables</a>
                     </li>
                     <li>

--- a/gc_little_helper_II.user.js
+++ b/gc_little_helper_II.user.js
@@ -289,6 +289,8 @@ var constInit = function(c) {
     bookmark("Unpublished Events", "/play/owner/unpublished/events", c.bookmarks);
     bookmark("Archived Events", "/play/owner/archived/events", c.bookmarks);
     bookmark("Treasures", "/play/treasure", c.bookmarks);
+    bookmark("Shareables", "/play/shareables", c.bookmarks);
+    bookmark("Public Profile Shareables", "/p/default.aspx?tab=shareables#profilepanel", c.bookmarks);
     // Custom Bookmark-title.
     c.bookmarks_orig_title = new Array();
     for (var i = 0; i < c.bookmarks.length; i++) {
@@ -1722,7 +1724,8 @@ var mainGC = function() {
                 $('body').prepend(header_old);
                 // Set z-index for old header on specific pages to prevent header elements from disappearing behind page elements:
                 // Search Map and Treasures: Prevent menus from disappearing behind icons (with v0.18.5).
-                if (is_page('searchmap') || document.location.href.match(/\.com\/play\/treasure/)) appendCssStyle('gclh_nav .wrapper {z-index: 2500;}');
+                // Shareables: Prevent menus from disappearing behind icons (with v0.18.12).
+                if (is_page('searchmap') || document.location.href.match(/\.com\/play\/treasure/) || document.location.href.match(/\.com\/play\/shareables/)) appendCssStyle('gclh_nav .wrapper {z-index: 2500;}');
                 // Run header relevant features.
                 tlc('START setUserParameter');
                 setUserParameter();
@@ -19209,7 +19212,7 @@ var mainGC = function() {
                     var outTitle = (typeof(bookmarks_orig_title[num]) != "undefined" && bookmarks_orig_title[num] != "" ? bookmarks_orig_title[num] : bookmarks[i]['title']);
                     html += ">" + outTitle + "</a>";
                     // if (num >= 75 && num <= 88) html += newParameterLL1; // Zeile belassen als Beispiel für zukünftige Einträge.
-                    if (num == 89) html += newParameterLL2;
+                    if (num >= 89 && num <= 91) html += newParameterLL2;
                 }
                 html += "  </td>";
                 // Zweite linke Spalte mit abweichenden Bezeichnungen:
@@ -19219,7 +19222,7 @@ var mainGC = function() {
                 } else {
                     html += "<input style='padding-left: 2px !important; padding-right: 2px !important;' class='gclh_form' title='Differing description for standard link' id='bookmarks_name[" + num + "]' type='text' size='15' value='" + repApo(getValue("settings_bookmarks_title[" + num + "]", "")) + "'>";
                     // if (num >= 75 && num <= 88) html += newParameterLLVersionSetzen("0.10"); // Zeile belassen als Beispiel für zukünftige Einträge.
-                    if (num == 89) html += newParameterLLVersionSetzen('0.18');
+                    if (num >= 89 && num <= 91) html += newParameterLLVersionSetzen('0.18');
                 }
                 html += "  </td></tr>";
             }


### PR DESCRIPTION
New link in Play Menü for "Shareables":

<img width="223" height="382" alt="2a" src="https://github.com/user-attachments/assets/fd9bcfdd-d2ae-4285-b2a2-e30dc9fdcf76" />

---
New Linklist links for "Shareables" and "Public Profile Shareables"

[Settings - Linklist and Navigation:
<img width="94" height="23" alt="3a2" src="https://github.com/user-attachments/assets/a17242a5-8aa5-452f-9026-82cf531b198b" />](https://www.geocaching.com/my/#GClhShowConfig#a#ll#gclh_LinkListElement_90)

[Settings - Linklist and Navigation:
<img width="177" height="25" alt="3a1" src="https://github.com/user-attachments/assets/094fada7-17af-4e86-8dd9-fc5b4953d7dc" />](https://www.geocaching.com/my/#GClhShowConfig#a#ll#gclh_LinkListElement_91)

---
Shareables websites: Prevent menus from disappearing behind icons

Before:
<img width="242" height="145" alt="1b" src="https://github.com/user-attachments/assets/f7f5970a-9edd-4a81-83ac-23e69e16dda4" />

After:
<img width="236" height="139" alt="1a" src="https://github.com/user-attachments/assets/05aab852-fc63-4388-9e85-e4f42160ba02" />
